### PR TITLE
Ensure consistent dimension check message in dot_product

### DIFF
--- a/WorkingFiles/Utils/MiscUtils.cpp
+++ b/WorkingFiles/Utils/MiscUtils.cpp
@@ -62,7 +62,7 @@ double MiscUtils::dot_product(const std::vector<double>& vector1, const std::vec
 int MiscUtils::dot_product(const std::vector<int>& vector1, const std::vector<int>& vector2) {
     if (vector1.size() != vector2.size()) {
         // Ensure that both vectors have the same dimension.
-        std::cerr << "Vectors must have the same dimension\"" << std::endl;
+        std::cerr << "Vectors must have the same dimension" << std::endl;
         throw std::exception();
     }
 
@@ -79,7 +79,7 @@ int MiscUtils::dot_product(const std::vector<int>& vector1, const std::vector<in
 double MiscUtils::dot_product(const std::vector<int>& vector1, const std::vector<double>& vector2) {
     if (vector1.size() != vector2.size()) {
         // Ensure that both vectors have the same dimension.
-        std::cerr << "Vectors must have the same dimension\"" << std::endl;
+        std::cerr << "Vectors must have the same dimension" << std::endl;
         throw std::exception();
     }
 
@@ -96,7 +96,7 @@ double MiscUtils::dot_product(const std::vector<int>& vector1, const std::vector
 double MiscUtils::dot_product(const std::vector<double>& vector1, const std::vector<int>& vector2) {
     if (vector1.size() != vector2.size()) {
         // Ensure that both vectors have the same dimension.
-        std::cerr << "Vectors must have the same dimension\"" << std::endl;
+        std::cerr << "Vectors must have the same dimension" << std::endl;
         throw std::exception();
     }
 


### PR DESCRIPTION
## Summary
- Fix extra escape character in `MiscUtils::dot_product` overloads so all report "Vectors must have the same dimension" when dimensions mismatch.

## Testing
- `g++ -std=c++17 $(find WorkingFiles -name '*.cpp' -print) -IWorkingFiles -o program`


------
https://chatgpt.com/codex/tasks/task_e_688d7d8695cc8326b3d33163997534cf