### PR TITLE
Fix agent turn order generation with skipped turns

### DIFF
--- a/WorkingFiles/Simulator/Simulator.cpp
+++ b/WorkingFiles/Simulator/Simulator.cpp
@@ -542,8 +542,17 @@ void Simulator::set_agent_turn_order() {
     // Generate a vector for the new turn order
     int iTotalTurns = get_micro_steps_per_macro_step();
     vector<int> vecNewTurnOrder;
-    for (int i = 0; i < iTotalTurns; i++) {
-        vecNewTurnOrder.push_back(i);
+
+    // Add each agent ID exactly once
+    for (const auto& pair : mapAgentIDToAgentPtr) {
+        vecNewTurnOrder.push_back(pair.first);
+    }
+
+    // Add placeholder IDs for skipped turns
+    int iSkipSlots = iTotalTurns - static_cast<int>(mapAgentIDToAgentPtr.size());
+    int iPlaceholderID = -1;
+    for (int i = 0; i < iSkipSlots; i++) {
+        vecNewTurnOrder.push_back(iPlaceholderID--);
     }
 
     // Shuffle the new turn order vector


### PR DESCRIPTION
## Summary
- derive agent turn order from actual agent IDs
- insert placeholder IDs for skip turns before shuffling

## Testing
- `g++ -std=c++17 $(find WorkingFiles -name '*.cpp') -o simulator`
- `./simulator /tmp/nonseq.json`


------
https://chatgpt.com/codex/tasks/task_e_688ea1cd1d988326b6fdc086e95728d3