### PR TITLE
Prevent market accumulation on simulator reset

### DIFF
--- a/WorkingFiles/Economy/Economy.cpp
+++ b/WorkingFiles/Economy/Economy.cpp
@@ -64,6 +64,10 @@ void Economy::add_market(Market market) {
     this->vecMarkets.push_back(market);
 }
 
+void Economy::clear_markets() {
+    this->vecMarkets.clear();
+}
+
 set<int> Economy::get_set_market_IDs() const {
     set<int> setMarketIDs;
     for (auto market : vecMarkets) {

--- a/WorkingFiles/Economy/Economy.h
+++ b/WorkingFiles/Economy/Economy.h
@@ -34,6 +34,7 @@ public:
 
     // Miscellaneous
     void add_market(Market market);
+    void clear_markets();
 
 private:
     int iPossibleCapabilities;

--- a/WorkingFiles/Simulator/Simulator.cpp
+++ b/WorkingFiles/Simulator/Simulator.cpp
@@ -430,6 +430,7 @@ int Simulator::init_markets() {
 
 int Simulator::reset_markets() {
     try {
+        this->economy.clear_markets();
         const auto& market_parameters = this->simulatorConfigs["default_market_parameters"];
         double dbVarCostMin = market_parameters["variable_cost_min"];
         double dbVarCostMax = market_parameters["variable_cost_max"];


### PR DESCRIPTION
## Summary
- add `clear_markets` method to `Economy` to reset internal market list
- invoke `clear_markets` at the start of `Simulator::reset_markets`
- remove temporary test files from repository

## Testing
- `g++ -std=c++17 -IWorkingFiles /tmp/test_reset_markets.cpp WorkingFiles/Action/Action.cpp WorkingFiles/Agent/BaseAgent.cpp WorkingFiles/Agent/ControlAgent.cpp WorkingFiles/Agent/StableBaselines3Agent.cpp WorkingFiles/DataCache/DataCache.cpp WorkingFiles/Economy/Economy.cpp WorkingFiles/Firm/Firm.cpp WorkingFiles/History/MasterHistory.cpp WorkingFiles/History/SimulationHistory.cpp WorkingFiles/Market/Market.cpp WorkingFiles/Simulator/Simulator.cpp WorkingFiles/Utils/MiscUtils.cpp WorkingFiles/Utils/StringUtils.cpp -o /tmp/test_reset_markets`
- `/tmp/test_reset_markets`


------
https://chatgpt.com/codex/tasks/task_e_688ea185e06883268d2b1239ca608005