### PR TITLE
Add safeguard against invalid timestep in reward calculation

### DIFF
--- a/WorkingFiles/Simulator/Simulator.cpp
+++ b/WorkingFiles/Simulator/Simulator.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <random>
 #include <cmath>
+#include <stdexcept>
 
 using std::map;
 using std::vector;
@@ -1772,6 +1773,9 @@ double Simulator::generate_reward(const int& iAgentID) {
     double dbPreviousCapital = mapAIAgentIDToCapitalAtLastTurn[iAgentID];
     int iPreviousMicroTimeStep = mapAIAgentIDToMicroTimeStepOfLastTurn[iAgentID];
     double dbCapitalChange = dbCurrentCapital - dbPreviousCapital;
+    if (iCurrentMicroTimeStep == iPreviousMicroTimeStep) {
+        throw std::runtime_error("generate_reward called with current and previous time steps equal");
+    }
     double dbAverageCapitalChange = dbCapitalChange / (iCurrentMicroTimeStep - iPreviousMicroTimeStep);
     return dbAverageCapitalChange;
 }


### PR DESCRIPTION
## Summary
- prevent invalid timestep usage when generating rewards by checking that the current micro time step differs from the previous one and throwing a runtime error if not
- include `<stdexcept>` to support runtime error handling

## Testing
- `g++ -std=c++17 $(find WorkingFiles -name '*.cpp') -IWorkingFiles -o simulator_build`


------
https://chatgpt.com/codex/tasks/task_e_688ec33b9a8c832694c15edea67a60e3