### PR TITLE
Handle empty market when computing average variable cost

### DIFF
--- a/WorkingFiles/Simulator/Simulator.cpp
+++ b/WorkingFiles/Simulator/Simulator.cpp
@@ -1339,6 +1339,10 @@ double Simulator::get_average_var_cost_in_market(Market market) {
 
     set<int> setFirmsInMarket = get_firm_IDs_in_market(market);
 
+    if (setFirmsInMarket.empty()) {
+        return 0.0;
+    }
+
     double dbTotalVarCost = 0.0;
     for (int iFirmID : setFirmsInMarket) {
         dbTotalVarCost += mapFirmToVarCost[iFirmID];


### PR DESCRIPTION
## Summary
- Avoid division by zero in `get_average_var_cost_in_market` by returning 0 when no firms are present.

## Testing
- `g++ -std=c++17 -c WorkingFiles/Simulator/Simulator.cpp`

------
https://chatgpt.com/codex/tasks/task_e_688ecf0c03008326acd57eeca850b75c