### PR TITLE
Add action ID bounds check

### DIFF
--- a/WorkingFiles/Simulator/Simulator.cpp
+++ b/WorkingFiles/Simulator/Simulator.cpp
@@ -745,11 +745,16 @@ vector<Action> Simulator::get_actions_for_all_agents_ai_agent_turn(const int& iA
 
 Action Simulator::convert_action_ID_to_action_object(const int& iActingAgentID, const int& iAIAgentActionID) {
     // The action space for the StableBaselines3 interface is a vector of length num_markets+1. An action ID less
-    // than or equal to num_markets represents a reversal of market presence in the given market. An action ID equal
+    // than num_markets represents a reversal of market presence in the given market. An action ID equal
     // to num_markets represents the do-nothing action.
 
+    const int iTotalMarkets = economy.get_total_markets();
+    if (iAIAgentActionID < 0 || iAIAgentActionID > iTotalMarkets) {
+        return Action::generate_none_action(iActingAgentID);
+    }
+
     // Do nothing action
-    if (iAIAgentActionID == economy.get_total_markets()) {
+    if (iAIAgentActionID == iTotalMarkets) {
         return Action::generate_none_action(iActingAgentID);
     }
 


### PR DESCRIPTION
## Summary
- add bounds check for action IDs in RL action conversion
- treat out-of-range IDs as none actions
- clarify comment describing action ID semantics

## Testing
- `g++ -std=c++17 $(find WorkingFiles -name '*.cpp') -IWorkingFiles -o sim_build`
- `./sim_build 2>&1 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688ecfd79c5c8326bf7d1a6134485420