### PR TITLE
Handle zero AI agents

### DIFF
--- a/WorkingFiles/Simulator/Simulator.cpp
+++ b/WorkingFiles/Simulator/Simulator.cpp
@@ -1781,6 +1781,11 @@ double Simulator::generate_reward(const int& iAgentID) {
 }
 
 int Simulator::get_next_AI_agent_index() {
+    if (iNumAIAgents == 0) {
+        // No AI agents available to act
+        return -1;
+    }
+
     int iAIAgentNumber = iNumAITurns % iNumAIAgents; // Which, of all the AI agents, is acting?
     // For example, if there are two AI agents,
     // this will either be 0 or 1. iNumAITurns


### PR DESCRIPTION
## Summary
- prevent division-by-zero in get_next_AI_agent_index when no AI agents exist
- return -1 if called without AI agents

## Testing
- `g++ -std=c++17 -c WorkingFiles/Simulator/Simulator.cpp -IWorkingFiles -IJSONReader`
- `make test` (fails: No rule to make target 'test')
- `ctest` (fails: No test configuration file found)


------
https://chatgpt.com/codex/tasks/task_e_68910cc10d54832688cd739446a06c96