### PR TITLE
Track firm-market exit costs separately

### DIFF
--- a/WorkingFiles/DataCache/DataCache.h
+++ b/WorkingFiles/DataCache/DataCache.h
@@ -19,6 +19,7 @@ This class stores current values for
     - the fixed cost            in the most recent micro time step for each firm-market combination
     - the variable cost         in the most recent micro time step for each firm-market combination
     - the entry cost            in the most recent micro time step for each firm-market combination
+    - the exit cost             in the most recent micro time step for each firm-market combination
     - the quantity produced     in the most recent micro time step for each firm-market combination
     - the price per unit        in the most recent micro time step for each firm-market combination
 
@@ -37,6 +38,7 @@ public:
     map<pair<int, int>, double> mapFirmMarketComboToFixedCost;
     map<pair<int, int>, double> mapFirmMarketComboToVarCost;
     map<pair<int, int>, double> mapFirmMarketComboToEntryCost;
+    map<pair<int, int>, double> mapFirmMarketComboToExitCost;
     map<pair<int, int>, double> mapFirmMarketComboToQtyProduced;
     map<pair<int, int>, double> mapFirmMarketComboToPrice;
 };


### PR DESCRIPTION
## Summary
- extend `DataCache` with `mapFirmMarketComboToExitCost` to store exit costs per firm-market pair
- compute and cache exit cost when entering a market; use cached value when exiting
- reset cached exit costs during initialization, exits, and bankruptcy handling

## Testing
- `g++ -std=c++17 WorkingFiles/main.cpp WorkingFiles/Simulator/Simulator.cpp WorkingFiles/Economy/Economy.cpp WorkingFiles/Agent/StableBaselines3Agent.cpp WorkingFiles/Agent/ControlAgent.cpp WorkingFiles/Agent/BaseAgent.cpp WorkingFiles/Market/Market.cpp WorkingFiles/Firm/Firm.cpp WorkingFiles/DataCache/DataCache.cpp WorkingFiles/History/SimulationHistory.cpp WorkingFiles/History/MasterHistory.cpp WorkingFiles/Utils/StringUtils.cpp WorkingFiles/Utils/MiscUtils.cpp WorkingFiles/Action/Action.cpp -IWorkingFiles -IJSONReader -o simulator_test`
- `./simulator_test WorkingFiles/Config/test_config.json`

------
https://chatgpt.com/codex/tasks/task_e_6892494a1b888326a809fb58b197c980