### PR TITLE
Prevent negative capital when entering markets

### DIFF
--- a/WorkingFiles/Simulator/Simulator.cpp
+++ b/WorkingFiles/Simulator/Simulator.cpp
@@ -813,6 +813,18 @@ int Simulator::execute_entry_action(const Action& action, map<int, double>* pMap
     auto pairFirmMarket = std::make_pair(firmPtr->getFirmID(), action.iMarketID);
     double dbEntryCost = dataCache.mapFirmMarketComboToEntryCost.at(pairFirmMarket);
 
+    // Ensure the firm has enough capital to cover the entry cost
+    double dbCurrentCapital = firmPtr->getDbCapital();
+    if (dbCurrentCapital < dbEntryCost) {
+        if (bVerbose) {
+            cout << "Firm " << firmPtr->getFirmID()
+                 << " lacks sufficient capital to enter market " << action.iMarketID
+                 << ". Required: " << dbEntryCost
+                 << ", available: " << dbCurrentCapital << endl;
+        }
+        return 0; // Skip action due to insufficient funds
+    }
+
     // Update capital within the firm object
     firmPtr->add_capital(-dbEntryCost);
 


### PR DESCRIPTION
## Summary
- Check firm's capital before charging entry cost.
- Skip market entry if funds are insufficient, logging a message in verbose mode.

## Testing
- `g++ -std=c++17 $(find WorkingFiles -name '*.cpp') -o simulator`
- `./simulator 2>&1 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68925f1b269083268f881557bdd8597b