### PR TITLE
Fix case-insensitive comparison

### DIFF
--- a/WorkingFiles/Utils/StringUtils.cpp
+++ b/WorkingFiles/Utils/StringUtils.cpp
@@ -1,5 +1,6 @@
 #include "StringUtils.h"
 #include <algorithm>
+#include <cctype>
 
 string StringUtils::toUpper(const string& str) {
     string result = str;
@@ -12,7 +13,8 @@ bool StringUtils::equalsIgnoreCase(const string& str1, const string& str2) {
         return false;
     }
     for (size_t i = 0; i < str1.size(); ++i) {
-        if (std::tolower(str1[i]) != std::tolower(str2[i])) {
+        if (std::tolower(static_cast<unsigned char>(str1[i])) !=
+            std::tolower(static_cast<unsigned char>(str2[i]))) {
             return false;
         }
     }


### PR DESCRIPTION
## Summary
- Ensure case-insensitive comparisons use unsigned char before `std::tolower` to avoid undefined behavior with negative char values.
- Include `<cctype>` for `std::tolower` usage.

## Testing
- `g++ -std=c++17 $(find WorkingFiles -name '*.cpp') -IWorkingFiles -w -o main3`
- `./main2` *(fails: Expected 1 command-line argument. Got 0)*

------
https://chatgpt.com/codex/tasks/task_e_6892686f379c8326bfd6a79323e522fd