### PR TITLE
Avoid copying exceptions by value

### DIFF
--- a/WorkingFiles/Firm/Firm.cpp
+++ b/WorkingFiles/Firm/Firm.cpp
@@ -40,7 +40,7 @@ int Firm::add_market_capabilities_to_firm_capabilities(const Market& market) {
         // Set firm capability vector to (firmCapVec ORed with marketCapVec)
         this->vecCapabilities = MiscUtils::element_wise_logical_or(this->vecCapabilities, market.get_vec_capabilities());
     }
-    catch (std::exception e) {
+    catch (const std::exception& e) {
         std::cerr << "Error adding market capabilities to firm capabilities" << std::endl;
         return 1;
     }
@@ -71,7 +71,7 @@ int Firm::remove_market_capabilities_from_firm_capabilities(const Market& market
         // Change all positive entries in the vector to a 1
         MiscUtils::set_all_positive_values_to_one(capabilitiesVector);
     }
-    catch (std::exception e) {
+    catch (const std::exception& e) {
         std::cerr << "Error removing market capabilities from firm capabilities" << std::endl;
         return 1;
     }

--- a/WorkingFiles/Simulator/Simulator.cpp
+++ b/WorkingFiles/Simulator/Simulator.cpp
@@ -590,7 +590,7 @@ int Simulator::perform_micro_step_control_agent_or_skip_turn(const int& iActingA
     try {
         vecActions = get_actions_for_all_agents_control_agent_turn(iActingAgentID);
     }
-    catch (std::exception e) {
+    catch (const std::exception& e) {
         cerr << "Error getting agent actions during micro step " << iCurrentMicroTimeStep << endl;
         cerr << e.what() << endl;
         return 1;
@@ -612,7 +612,7 @@ int Simulator::perform_micro_step_ai_agent_turn(const int& iActingAgentID, const
     try {
         vecActions = get_actions_for_all_agents_ai_agent_turn(iActingAgentID, iAIAgentActionID);
     }
-    catch (std::exception e) {
+    catch (const std::exception& e) {
         cerr << "Error getting agent actions during micro step " << iCurrentMicroTimeStep << endl;
         cerr << e.what() << endl;
         return 1;
@@ -711,7 +711,7 @@ vector<Action> Simulator::get_actions_for_all_agents_control_agent_turn(const in
                 try {
                     vecActions.emplace_back(get_agent_action(*controlAgentPtr));
                 }
-                catch (std::exception e) {
+                catch (const std::exception& e) {
                     cerr << "Error getting actions for control agents" << e.what() << endl;
                     throw std::exception();
                 }
@@ -1268,7 +1268,7 @@ int Simulator::distribute_profits(map<int, double>* pMapFirmIDToCapitalChange) {
                 auto pAgent = get_agent_ptr_from_firm_ID(iFirmID);
                 policy = pAgent->get_enum_production_policy();
             }
-            catch (std::exception e) {
+            catch (const std::exception& e) {
                 cerr << "Error in distribute_profits method: " << e.what() << endl;
                 return 1;
             }


### PR DESCRIPTION
## Summary
- Use `const std::exception&` in catch handlers for simulator micro-steps and profit distribution
- Catch exceptions by const reference in firm capability updates
- Confirmed all exception handlers capture by reference rather than by value

## Testing
- `g++ -std=c++17 $(find . -name '*.cpp') -I. -o bss`
- `rg "catch \(" -n`


------
https://chatgpt.com/codex/tasks/task_e_689268ce9e3c83268dd382fddd743f47