### PR TITLE
Handle missing simulation history

### DIFF
--- a/WorkingFiles/History/MasterHistory.cpp
+++ b/WorkingFiles/History/MasterHistory.cpp
@@ -6,12 +6,16 @@
 #include <iostream>
 #include <fstream>
 #include <cmath>
+#include <stdexcept>
 
 using std::string;
 using std::cout;
 using std::endl;
 
 SimulationHistory* MasterHistory::getCurrentSimulationHistoryPtr() {
+    if (vecSimulationHistoryPtrs.empty()) {
+        throw std::runtime_error("No simulation histories are available");
+    }
     return vecSimulationHistoryPtrs.back();
 }
 

--- a/WorkingFiles/Simulator/Simulator.cpp
+++ b/WorkingFiles/Simulator/Simulator.cpp
@@ -151,8 +151,14 @@ int Simulator::reset() {
 
     // Initialize the history and the data cache
     init_simulation_history();
-    if (init_data_cache(masterHistory.getCurrentSimulationHistoryPtr()))
+    try {
+        if (init_data_cache(masterHistory.getCurrentSimulationHistoryPtr()))
+            return 1;
+    }
+    catch (const std::runtime_error& e) {
+        cerr << "Error retrieving current simulation history: " << e.what() << endl;
         return 1;
+    }
 
     // Initialize maps for tracking statistics necessary for AI reward calculations
     for (auto pair : mapAgentIDToAgentPtr) {


### PR DESCRIPTION
## Summary
- prevent `MasterHistory::getCurrentSimulationHistoryPtr` from accessing empty history list and throw a descriptive exception when no histories are present
- handle potential failure to obtain a simulation history during reset by catching the exception and reporting an error

## Testing
- `g++ -std=c++17 $(find WorkingFiles -name '*.cpp') -IWorkingFiles -IJSONReader -o simulator`


------
https://chatgpt.com/codex/tasks/task_e_6892c2980494832699af8b9e3b4ec2c0