### PR TITLE
Use unsigned-char safe toupper

### DIFF
--- a/WorkingFiles/Utils/StringUtils.cpp
+++ b/WorkingFiles/Utils/StringUtils.cpp
@@ -4,7 +4,10 @@
 
 string StringUtils::toUpper(const string& str) {
     string result = str;
-    std::transform(result.begin(), result.end(), result.begin(), ::toupper);
+    std::transform(result.begin(), result.end(), result.begin(),
+                   [](unsigned char c) -> char {
+                       return static_cast<char>(std::toupper(c));
+                   });
     return result;
 }
 


### PR DESCRIPTION
## Summary
- Avoid undefined behavior in `StringUtils::toUpper` by casting characters to unsigned char before `std::toupper`

## Testing
- `g++ -std=c++17 test_stringutils.cpp WorkingFiles/Utils/StringUtils.cpp -o test_stringutils`
- `./test_stringutils`


------
https://chatgpt.com/codex/tasks/task_e_6892c2646f40832690dde83c725cee8d