### PR TITLE
Replace error codes with exceptions in simulator

### DIFF
--- a/WorkingFiles/Simulator/Simulator.h
+++ b/WorkingFiles/Simulator/Simulator.h
@@ -27,15 +27,15 @@ class Simulator {
 public:
     Simulator();
     bool bTrainingMode = false; // Only turn this on from within the Python API
-    int load_json_configs(const string& strConfigFilePath);
+    void load_json_configs(const string& strConfigFilePath);
     void init_master_history();
     void init_simulation_history();
     int init_data_cache(SimulationHistory* pCurrentSimulationHistory);
-    int prepare_to_run();
+    void prepare_to_run();
     void set_agent_turn_order();
     // vector<int> get_agent_turn_order();
     int reset();
-    int run();
+    void run();
     int get_num_sims() const;
     // int get_macro_steps_per_sim() const;
     int iCurrentMacroTimeStep = 0;
@@ -43,8 +43,8 @@ public:
     MasterHistory masterHistory;
     bool bVerbose{};
     bool bGenerateMasterOutput{};
-    int perform_micro_step_control_agent_or_skip_turn(const int& iActingAgentID);
-    int perform_micro_step_ai_agent_turn(const int& iActingAgentID, const int& iAIAgentActionID);
+    void perform_micro_step_control_agent_or_skip_turn(const int& iActingAgentID);
+    void perform_micro_step_ai_agent_turn(const int& iActingAgentID, const int& iAIAgentActionID);
     int perform_micro_step_helper(const vector<Action>& vecActions);
     int get_micro_steps_per_macro_step();
     bool is_ai_agent(const int& iAgentID);
@@ -101,15 +101,15 @@ private:
     int iNumAIAgents = 0;
     int iNumAITurns = 0;
 
-    int init_control_agents();
-    int init_AI_agents();
-    int init_economy();
-    int init_markets();
+    void init_control_agents();
+    void init_AI_agents();
+    void init_economy();
+    void init_markets();
     int reset_economy();
     int reset_markets();
-    int set_simulation_parameters();
+    void set_simulation_parameters();
     // int set_fixed_cost_for_existence();
-    int init_firms_for_agents();
+    void init_firms_for_agents();
     vector<int> create_market_capability_vector(const double& dbMean, const double& dbSD);
     vector<Action> get_actions_for_all_agents_control_agent_turn(const int& iActingAgentID);
     vector<Action> get_actions_for_all_agents_ai_agent_turn(const int& iActingAgentID, const int& iAIAgentActionID);

--- a/WorkingFiles/main.cpp
+++ b/WorkingFiles/main.cpp
@@ -22,41 +22,34 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
-    // Create simulator instance
-    Simulator simulator;
-
     try {
+        Simulator simulator;
         validate_config(argv[1]);
+        simulator.load_json_configs(argv[1]);
+        simulator.prepare_to_run();
+
+        for (int iSim = 0; iSim < simulator.get_num_sims(); iSim++) {
+            cout << "Beginning simulation " << iSim << " of " << simulator.get_num_sims() - 1 << " (indexed at 0)" << endl;
+            if (simulator.reset())
+                return 1;
+
+            simulator.run();
+        }
+
+        if (simulator.bGenerateMasterOutput) {
+            if (simulator.masterHistory.generate_master_output()) {
+                cerr << "Error generating master output file" << endl;
+                return 1;
+            }
+            if (simulator.masterHistory.generate_market_overlap_file()) {
+                cerr << "Error generating market overlap file" << endl;
+                return 1;
+            }
+        }
     }
     catch (const std::exception& e) {
         cerr << e.what() << endl;
         return 1;
-    }
-
-    if (simulator.load_json_configs(argv[1]))
-        return 1;
-
-    if (simulator.prepare_to_run())
-        return 1;
-
-    for (int iSim = 0; iSim < simulator.get_num_sims(); iSim++) {
-        cout << "Beginning simulation " << iSim << " of " << simulator.get_num_sims() - 1 << " (indexed at 0)" << endl;
-        if (simulator.reset())
-            return 1;
-
-        if (simulator.run())
-            return 1;
-    }
-
-    if (simulator.bGenerateMasterOutput) {
-        if (simulator.masterHistory.generate_master_output()) {
-            cerr << "Error generating master output file" << endl;
-            return 1;
-        }
-        if (simulator.masterHistory.generate_market_overlap_file()) {
-            cerr << "Error generating market overlap file" << endl;
-            return 1;
-        }
     }
 
     return 0;


### PR DESCRIPTION
## Summary
- replace integer error codes with exceptions across simulator setup and micro-step functions
- simplify main control flow to rely on exceptions rather than status codes

## Testing
- `g++ -std=c++17 -Wall -Wextra -IJSONReader -IWorkingFiles -I. $(find WorkingFiles -name '*.cpp') -o simulator_app`
- `./simulator_app WorkingFiles/Config/default.json`

------
https://chatgpt.com/codex/tasks/task_e_68938e6f6f5c8326bc35372c38dbbd3f