### PR TITLE
Replace remaining error codes with exceptions

### DIFF
--- a/WorkingFiles/main.cpp
+++ b/WorkingFiles/main.cpp
@@ -6,6 +6,7 @@ Use business_strategy_gym_env.py or another Python script for training AI agents
 #include <exception>
 #include <iostream>
 #include <string>
+#include <stdexcept>
 #include "Simulator/Simulator.h"
 #include "Config/ConfigValidator.h"
 
@@ -16,13 +17,12 @@ using std::endl;
 
 int main(int argc, char* argv[]) {
 
-    // Check for correct number of command-line arguments
-    if (argc != 2) {
-        cerr << "Expected 1 command-line argument. Got " << argc - 1 << endl;
-        return 1;
-    }
-
     try {
+        // Check for correct number of command-line arguments
+        if (argc != 2) {
+            throw std::invalid_argument("Expected 1 command-line argument. Got " + std::to_string(argc - 1));
+        }
+
         Simulator simulator;
         validate_config(argv[1]);
         simulator.load_json_configs(argv[1]);


### PR DESCRIPTION
## Summary
- Use exceptions for invalid CLI argument count instead of returning error codes.

## Testing
- `g++ -std=c++17 -fsyntax-only $(find WorkingFiles -name '*.cpp') -IJSONReader`


------
https://chatgpt.com/codex/tasks/task_e_6893b6e2094c83269b4cdfc6df7a6b2c