### PR TITLE
Align master history with simulator rounding

### DIFF
--- a/WorkingFiles/Simulator/Simulator.cpp
+++ b/WorkingFiles/Simulator/Simulator.cpp
@@ -338,9 +338,8 @@ int Simulator::set_fixed_cost_for_existence() {
 }
 
 void Simulator::init_master_history() {
-    // Get the number of micro steps per macro step
-    double dbMicroStepsPerMacroStep = static_cast<double>(mapAgentIDToAgentPtr.size()) * (1.0 + dbSkippedTurnsPerRegularTurn);
-    int iMicroStepsPerMacroStep = static_cast<int>(std::round(dbMicroStepsPerMacroStep));
+    // Get the number of micro steps per macro step using the simulator's rounding strategy
+    int iMicroStepsPerMacroStep = get_micro_steps_per_macro_step();
 
     masterHistory.iMicroStepsPerSim = iMicroStepsPerMacroStep * iMacroStepsPerSim;
     masterHistory.iNumFirms = static_cast<int>(mapFirmIDToFirmPtr.size());


### PR DESCRIPTION
## Summary
- Use `get_micro_steps_per_macro_step()` when initializing master history so rounding matches simulator logic.

## Testing
- `g++ -std=c++17 -IJSONReader $(find WorkingFiles -name '*.cpp') -o simulator`


------
https://chatgpt.com/codex/tasks/task_e_6893bba6780c8326a330de5f0b7a20dc