### PR TITLE
Recalculate fixed cost each reset

### DIFF
--- a/WorkingFiles/Simulator/Simulator.cpp
+++ b/WorkingFiles/Simulator/Simulator.cpp
@@ -113,6 +113,10 @@ void Simulator::reset() {
         throw std::runtime_error("economy contains no markets after reset");
     }
 
+    if (bFixedCostForExistence) {
+        set_fixed_cost_for_existence();
+    }
+
     // Clear out the agent turn order
     vecAgentTurnOrder.clear();
 
@@ -325,7 +329,7 @@ void Simulator::init_firms_for_agents() {
     }
 }
 
-int Simulator::set_fixed_cost_for_existence() {
+void Simulator::set_fixed_cost_for_existence() {
     int iMicroStepsPerSim = this->iMacroStepsPerSim * get_micro_steps_per_macro_step();
 
     // Set the fixed cost for existence such that capital depletes linearly to zero over the course of the simulation
@@ -333,8 +337,6 @@ int Simulator::set_fixed_cost_for_existence() {
     double dbDefaultStartingCapital = firm_parameters["starting_capital"];
 
     this->dbFixedCostForExistence = dbDefaultStartingCapital / iMicroStepsPerSim;
-
-    return 0;
 }
 
 void Simulator::init_master_history() {

--- a/WorkingFiles/Simulator/Simulator.h
+++ b/WorkingFiles/Simulator/Simulator.h
@@ -108,7 +108,7 @@ private:
     void reset_economy();
     void reset_markets();
     void set_simulation_parameters();
-    int set_fixed_cost_for_existence();
+    void set_fixed_cost_for_existence();
     void init_firms_for_agents();
     vector<int> create_market_capability_vector(const double& dbMean, const double& dbSD);
     vector<Action> get_actions_for_all_agents_control_agent_turn(const int& iActingAgentID);


### PR DESCRIPTION
## Summary
- Change `set_fixed_cost_for_existence` to return void in simulator interface and implementation.
- Invoke fixed-cost calculation during `reset()` so costs adjust each run.

## Testing
- `g++ -std=c++17 -fsyntax-only WorkingFiles/Simulator/Simulator.cpp -IWorkingFiles -IJSONReader`


------
https://chatgpt.com/codex/tasks/task_e_6893bbc2bd14832683606092a2195403