### PR TITLE
Skip fixed cost deduction when capital depleted

### DIFF
--- a/WorkingFiles/Simulator/Simulator.cpp
+++ b/WorkingFiles/Simulator/Simulator.cpp
@@ -597,6 +597,10 @@ void Simulator::perform_micro_step_helper(const vector<Action>& vecActions) {
     // Subtract the fixed existence cost from each firm
     if (this->bFixedCostForExistence) {
         for (auto firmID : get_set_firm_IDs()) {
+            auto pFirm = mapFirmIDToFirmPtr.at(firmID);
+            if (pFirm->getDbCapital() <= 0.0) {
+                continue;
+            }
             // Update capital within the firm object
             add_profit_to_firm(-dbFixedCostForExistence, firmID);
             mapFirmIDToCapitalChange.at(firmID) -= this->dbFixedCostForExistence;


### PR DESCRIPTION
## Summary
- Avoid deducting fixed existence cost from firms with non-positive capital.

## Testing
- `g++ -std=c++17 -IWorkingFiles -IJSONReader -c WorkingFiles/Simulator/Simulator.cpp -o /tmp/Simulator.o`
- `ls /tmp`

------
https://chatgpt.com/codex/tasks/task_e_6893bbd070ec8326b52b80a3a18b1278