### PR TITLE
Add vector and tuple includes to PythonAPI header

### DIFF
--- a/WorkingFiles/PythonAPI/PythonAPI.h
+++ b/WorkingFiles/PythonAPI/PythonAPI.h
@@ -7,12 +7,13 @@
 #include "../Simulator/Simulator.h"
 #include <iostream>
 #include <string>
+#include <vector>
+#include <tuple>
 
-using std::cerr;
 using std::cout;
 using std::endl;
 using std::tuple;
-using std::map;
+using std::vector;
 
 class PythonAPI {
 public:


### PR DESCRIPTION
## Summary
- include `<vector>` and `<tuple>` in `PythonAPI.h`
- clean up unused using declarations

## Testing
- `cmake -S . -B build` *(fails: CMake 3.31 or higher is required. You are running version 3.28.3)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895057ce1088326bce43eaaa61eee41