### PR TITLE
Ensure consistent types for gym observations and rewards

### DIFF
--- a/business_strategy_gym_env.py
+++ b/business_strategy_gym_env.py
@@ -54,11 +54,15 @@ class BusinessStrategyEnv(gym.Env):
         self.observation_space = obs_space
 
     def reset(self, seed=None, options=None):
-        observation, info = self.python_API.reset(), {}
+        super().reset(seed=seed)
+        observation = np.array(self.python_API.reset(), dtype=np.float32)
+        info = {}
         return observation, info
 
     def step(self, action):
         observation, reward, terminated, truncated = self.python_API.step(action)
+        observation = np.array(observation, dtype=np.float32)
+        reward = float(reward)
         info = {}
         return observation, reward, terminated, truncated, info
 


### PR DESCRIPTION
## Summary
- Call `super().reset()` and convert reset observation to `np.float32`
- Cast step observations to `np.float32` and rewards to `float`

## Testing
- `python -m py_compile business_strategy_gym_env.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689505cb59348326aac9ebc792f61302