### PR TITLE
Guard training routine and make paths configurable

### DIFF
--- a/business_strategy_gym_env.py
+++ b/business_strategy_gym_env.py
@@ -1,8 +1,6 @@
 import simulator_module
 import gymnasium as gym
 import numpy as np
-import stable_baselines3
-
 
 class BusinessStrategyEnv(gym.Env):
     def __init__(self, path_to_config_file):
@@ -69,14 +67,36 @@ class BusinessStrategyEnv(gym.Env):
         self.python_API.close()
 
 
-# Define and train an RL agent
-n_steps = 2048  # StableBaselines3 default value
-n_envs = 1  # StableBaselines3 default value
-num_updates = 1
-total_steps = n_steps * n_envs * num_updates
+if __name__ == "__main__":
+    from pathlib import Path
+    import argparse
+    import stable_baselines3
 
-path_to_default_config_file = '/Users/eric/CLionProjects/BusinessStrategy2.0/WorkingFiles/Config/default.json'
-env = BusinessStrategyEnv(path_to_default_config_file)
-model = stable_baselines3.PPO("MlpPolicy", env, verbose=1)
-model.learn(total_timesteps=total_steps)
-model.save("/Users/eric/CLionProjects/BusinessStrategy2.0/AgentFiles/Agent.zip")
+    parser = argparse.ArgumentParser(description="Train a PPO agent in the BusinessStrategyEnv.")
+    base_dir = Path(__file__).resolve().parent
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=base_dir / "WorkingFiles" / "Config" / "default.json",
+        help="Path to the simulator configuration file.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=base_dir / "AgentFiles" / "Agent.zip",
+        help="Path where the trained model will be saved.",
+    )
+    parser.add_argument(
+        "--num_updates", type=int, default=1, help="Number of PPO update iterations."
+    )
+    args = parser.parse_args()
+
+    n_steps = 2048  # StableBaselines3 default value
+    n_envs = 1  # StableBaselines3 default value
+    total_steps = n_steps * n_envs * args.num_updates
+
+    env = BusinessStrategyEnv(str(args.config))
+    model = stable_baselines3.PPO("MlpPolicy", env, verbose=1)
+    model.learn(total_timesteps=total_steps)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    model.save(str(args.output))


### PR DESCRIPTION
## Summary
- Move the PPO training routine into an `if __name__ == "__main__":` block and import `stable_baselines3` locally
- Allow configurable config and model paths using `argparse` with defaults relative to the repository

## Testing
- `python -m py_compile business_strategy_gym_env.py`
- `python -B business_strategy_gym_env.py --help` *(fails: No module named 'simulator_module')*

------
https://chatgpt.com/codex/tasks/task_e_689505eacdc0832692dfd80e4bb259c5