### PR TITLE
Ensure deterministic simulation

### DIFF
--- a/simulator.py
+++ b/simulator.py
@@ -8,6 +8,6 @@ def simulate(path, obs: tuple):
     global model
     if model is None:
         model = PPO.load(path)
-    convertedObs = np.array(obs)
-    action, _hidden = model.predict(convertedObs)
-    return action
+    convertedObs = np.array(obs, dtype=np.float32)
+    action, _hidden = model.predict(convertedObs, deterministic=True)
+    return int(action)


### PR DESCRIPTION
## Summary
- Cast observations to float32 arrays before prediction
- Use deterministic policy evaluation for consistent actions
- Return actions as plain integers for C++ integration

## Testing
- `pytest`
- `python -m py_compile simulator.py`


------
https://chatgpt.com/codex/tasks/task_e_689654ebe9208326b5586211b737d816