### PR TITLE
Fix Python path for simulator script

### DIFF
--- a/WorkingFiles/main.cpp
+++ b/WorkingFiles/main.cpp
@@ -28,8 +28,8 @@ int main(int argc, char* argv[]) {
         py::scoped_interpreter guard{}; // start the interpreter and keep it alive
         py::object simulate_function;
 
-        // Add the directory containing the script to the Python path
-        py::module::import("sys").attr("path").attr("append")("AgentFiles/Agent.zip");
+        // Add the project root (which contains simulator.py) to the Python path
+        py::module::import("sys").attr("path").attr("append")("../");
 
         // Import the script
         py::module script = py::module::import("simulator");


### PR DESCRIPTION
## Summary
- ensure simulator.py directory is on Python path when running C++ main

## Testing
- `cmake -S . -B build` *(fails: CMake 3.31 or higher is required. You are running version 3.28.3)*

------
https://chatgpt.com/codex/tasks/task_e_6896550c7d0c8326bf7d057a7f9484a0