### PR TITLE
Validate model path before loading

### DIFF
--- a/simulator.py
+++ b/simulator.py
@@ -1,12 +1,16 @@
 from stable_baselines3 import PPO
 import numpy as np
+import os
 
 # Global variable to store the model
 model = None
 
+
 def simulate(path, obs: tuple):
     global model
     if model is None:
+        if not os.path.isfile(path):
+            raise FileNotFoundError(f"Model file not found at: {path}")
         model = PPO.load(path)
     convertedObs = np.array(obs)
     action, _hidden = model.predict(convertedObs)


### PR DESCRIPTION
## Summary
- verify PPO model path exists before loading

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896553166508326bedf478ff3880a24