### PR TITLE
Return agent path by const reference

### DIFF
--- a/WorkingFiles/Agent/BaseAgent.cpp
+++ b/WorkingFiles/Agent/BaseAgent.cpp
@@ -8,6 +8,6 @@ int BaseAgent::get_agent_ID() const {
     return iAgentID;
 }
 
-[[maybe_unused]] string BaseAgent::get_path_to_agent() const {
+[[maybe_unused]] const string& BaseAgent::get_path_to_agent() const {
     return strPathToAgent;
 }

--- a/WorkingFiles/Agent/BaseAgent.h
+++ b/WorkingFiles/Agent/BaseAgent.h
@@ -24,7 +24,7 @@ public:
     [[nodiscard]] virtual string to_string() const = 0;
     [[nodiscard]] virtual ProductionPolicy get_enum_production_policy() const = 0;
     [[nodiscard]] int get_agent_ID() const;
-    [[maybe_unused]] [[nodiscard]] string get_path_to_agent() const;
+    [[maybe_unused]] [[nodiscard]] const string& get_path_to_agent() const;
     virtual ~BaseAgent() = default;
 
 protected:

--- a/WorkingFiles/Simulator/Simulator.cpp
+++ b/WorkingFiles/Simulator/Simulator.cpp
@@ -43,7 +43,7 @@ void Simulator::run(py::object simulate_function) {
                 vector<double> stateObs = generate_state_observation(iAgentID);
                 py::tuple obs = py::tuple(py::cast(stateObs));
 
-                py::object result = simulate_function(mapAgentIDToAgentPtr[iAgentID]->get_path_to_agent().c_str(),obs);
+                py::object result = simulate_function(mapAgentIDToAgentPtr[iAgentID]->get_path_to_agent(), obs);
 
                 int action = result.cast<int>();
 


### PR DESCRIPTION
## Summary
- Return agent path as const reference from BaseAgent
- Pass agent path string directly when invoking simulate_function

## Testing
- `cmake -S . -B build` *(fails: CMake 3.31 or higher is required)*
- `pip install --quiet --upgrade cmake` *(fails: Could not find a version that satisfies the requirement cmake)*

------
https://chatgpt.com/codex/tasks/task_e_689655717a988326890eb0fb63dc8685