### PR TITLE
Handle missing agent pointers in Simulator::run

### DIFF
--- a/WorkingFiles/Simulator/Simulator.cpp
+++ b/WorkingFiles/Simulator/Simulator.cpp
@@ -43,7 +43,12 @@ void Simulator::run(py::object simulate_function) {
                 vector<double> stateObs = generate_state_observation(iAgentID);
                 py::tuple obs = py::cast(stateObs);
 
-                py::object result = simulate_function(mapAgentIDToAgentPtr[iAgentID]->get_path_to_agent(), obs);
+                auto it = mapAgentIDToAgentPtr.find(iAgentID);
+                if (it == mapAgentIDToAgentPtr.end() || it->second == nullptr) {
+                    throw std::runtime_error("AI agent ID " + std::to_string(iAgentID) + " not found or null");
+                }
+
+                py::object result = simulate_function(it->second->get_path_to_agent(), obs);
 
                 int action = result.cast<int>();
 


### PR DESCRIPTION
## Summary
- Ensure Simulator::run verifies agent lookup before calling simulate_function
- Throw runtime error if an AI agent ID is missing or null

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68965b328cc883269f5da92f0341ca39