### PR TITLE
Enable MPS device in PPO training and document PyTorch requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # BusinessStrategySimulator3
+
+## Requirements
+
+This environment relies on PyTorch for training reinforcement learning agents.
+To take advantage of Apple Silicon GPUs, install PyTorch ≥1.12 with MPS
+support. The MPS backend is available in official releases and nightly builds:
+
+```bash
+pip install torch --pre --index-url https://download.pytorch.org/whl/nightly/cpu
+```
+
+If you already have a compatible version of PyTorch, the standard
+`pip install torch` is sufficient.

--- a/business_strategy_gym_env.py
+++ b/business_strategy_gym_env.py
@@ -75,6 +75,8 @@ class BusinessStrategyEnv(gym.Env):
         self.python_API.close()
 
 if __name__ == "__main__":
+    import torch
+    device = torch.device("mps" if torch.backends.mps.is_available() else "cpu")
     from pathlib import Path
     import argparse
     import stable_baselines3
@@ -103,7 +105,7 @@ if __name__ == "__main__":
     total_steps = n_steps * n_envs * args.num_updates
 
     env = BusinessStrategyEnv(str(args.config))
-    model = stable_baselines3.PPO("MlpPolicy", env, verbose=1)
+    model = stable_baselines3.PPO("MlpPolicy", env, device=device, verbose=1)
     model.learn(total_timesteps=total_steps)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     model.save(str(args.output))


### PR DESCRIPTION
## Summary
- Detect Apple Silicon's MPS backend and select GPU or CPU device accordingly
- Pass configured device to Stable Baselines3 PPO trainer
- Document requirement for PyTorch ≥1.12 with MPS support and nightly install option

## Testing
- `python -m py_compile business_strategy_gym_env.py`
- `python business_strategy_gym_env.py --help` *(fails: ModuleNotFoundError: No module named 'simulator_module')*


------
https://chatgpt.com/codex/tasks/task_e_6897aa7e9e9c832680b67d87dc6cd29a