### PR TITLE
Add reduce_output_file_size option

### DIFF
--- a/WorkingFiles/Config/ConfigValidator.cpp
+++ b/WorkingFiles/Config/ConfigValidator.cpp
@@ -43,6 +43,8 @@ void validate_config(const std::string& strConfigFilePath) {
             "simulation_parameters.generate_master_output must be a boolean");
     require(sim.contains("verbose") && sim["verbose"].is_boolean(),
             "simulation_parameters.verbose must be a boolean");
+    require(sim.contains("reduce_output_file_size") && sim["reduce_output_file_size"].is_boolean(),
+            "simulation_parameters.reduce_output_file_size must be a boolean");
     require(sim.contains("randomize_turn_order_within_each_macro_step") &&
             sim["randomize_turn_order_within_each_macro_step"].is_boolean(),
             "simulation_parameters.randomize_turn_order_within_each_macro_step must be a boolean");

--- a/WorkingFiles/Config/default.json
+++ b/WorkingFiles/Config/default.json
@@ -6,6 +6,7 @@
     "skipped_turns_per_regular_turn": 1,
     "generate_master_output": true,
     "verbose": false,
+    "reduce_output_file_size": false,
     "randomize_turn_order_within_each_macro_step": true,
     "randomize_agent_firm_assignment_per_simulation": false,
     "randomize_variable_costs_per_simulation": true,

--- a/WorkingFiles/Simulator/Simulator.cpp
+++ b/WorkingFiles/Simulator/Simulator.cpp
@@ -175,6 +175,7 @@ void Simulator::set_simulation_parameters() {
         this->iMacroStepsPerSim = simulation_parameters["macro_steps_per_sim"];
         this->dbSkippedTurnsPerRegularTurn = simulation_parameters["skipped_turns_per_regular_turn"];
         this->bVerbose = simulation_parameters["verbose"];
+        this->bReduceOutputFileSize = simulation_parameters["reduce_output_file_size"];
         this->bFixedCostForExistence = simulation_parameters["fixed_cost_for_existence"];
         this->bGenerateMasterOutput = simulation_parameters["generate_master_output"];
         this->bRandomizeTurnOrderWithinEachMacroStep = simulation_parameters["randomize_turn_order_within_each_macro_step"];
@@ -1105,7 +1106,29 @@ void Simulator::init_simulation_history() {
     for (auto pair : mapAgentToFirm) {
         int iFirmID = pair.second;
         auto pAgent = get_agent_ptr_from_firm_ID(iFirmID);
-        mapFirmIDToAgentDescriptions[iFirmID] = pAgent->to_string();
+        if (bReduceOutputFileSize) {
+            string strAbbrev;
+            if (pAgent->enumAgentType == AgentType::StableBaselines3) {
+                strAbbrev = "AI";
+            }
+            else if (auto pControl = dynamic_cast<ControlAgent*>(pAgent)) {
+                if (pControl->get_enum_entry_policy() == EntryPolicy::HighestOverlap &&
+                    pControl->get_enum_exit_policy() == ExitPolicy::Loss) {
+                    strAbbrev = "S";
+                }
+                else {
+                    strAbbrev = "N";
+                }
+            }
+            else {
+                strAbbrev = "N";
+            }
+            mapFirmIDToAgentDescriptions[iFirmID] =
+                    std::to_string(pAgent->get_agent_ID()) + strAbbrev;
+        }
+        else {
+            mapFirmIDToAgentDescriptions[iFirmID] = pAgent->to_string();
+        }
     }
 
     // Initialize the simulation history using the above four maps

--- a/WorkingFiles/Simulator/Simulator.h
+++ b/WorkingFiles/Simulator/Simulator.h
@@ -93,6 +93,7 @@ private:
     // Markets are regenerated automatically when the economy is randomized.
     // This flag triggers market regeneration even when the economy remains the same.
     bool bRandomizeMarketsPerSimulation{};
+    bool bReduceOutputFileSize{};
 
 
     // Maps to track stats necessary for reward calculations


### PR DESCRIPTION
## Summary
- add boolean `reduce_output_file_size` to config and validator
- support compact agent type strings in simulator when option is enabled

## Testing
- `cmake .. && cmake --build .` *(fails: CMake 3.31 or higher is required. You are running version 3.28.3)*

------
https://chatgpt.com/codex/tasks/task_e_6897e3f98ae08326abffaefee6c65622