### PR TITLE
Document cluster usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,46 @@ Install Python dependencies (e.g., `gymnasium`, `stable-baselines3`, `torch`, an
 python business_strategy_gym_env.py --config WorkingFiles/Config/default.json --output AgentFiles/Agent.zip
 ```
 
+## Running on a compute cluster
+
+When launching a single training job on a shared compute resource:
+
+1. Ensure the simulator module is discoverable. Either copy the compiled extension into your project directory or add the build
+   output to your Python path:
+   ```
+   export PYTHONPATH=/path/to/BusinessStrategySimulator3/cmake-build-debug:$PYTHONPATH
+   ```
+2. Activate the virtual environment used for experiments:
+   ```
+   source /path/to/BusinessStrategySimulator3/.venv/bin/activate
+   ```
+3. Choose the command-line flags that match your experiment. Available options are summarized below.
+4. Launch training:
+   ```
+   python business_strategy_gym_env.py [flags]
+   ```
+
+### Training script flags
+
+| Flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--config` | Path | `WorkingFiles/Config/default.json` | Path to the simulator configuration file. |
+| `--output` | Path | `AgentFiles/Agent.zip` | Location where the trained model checkpoint will be saved. |
+| `--num_updates` | int | `500` | Number of PPO update iterations to perform. |
+| `--n-envs` | int | `10` | Number of parallel environments to run during training. |
+| `--use_gpu` | flag | _disabled_ | Use an available GPU (e.g., Apple MPS) instead of the CPU. |
+
+Example cluster command:
+
+```
+python business_strategy_gym_env.py \
+    --config /path/to/BusinessStrategySimulator3/WorkingFiles/Config/default.json \
+    --output /path/to/BusinessStrategySimulator3/AgentFiles/Agent.zip \
+    --num_updates 3 \
+    --n-envs 5 \
+    --use_gpu
+```
+
 ## Using a trained model
 
 The `simulator.py` helper loads a saved model and returns an action for a given observation:


### PR DESCRIPTION
## Summary
- add compute-cluster workflow guidance for running single training jobs
- provide table summarizing available training script flags
- include example command with generic paths for privacy

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d3021aafc08326a862c01b069b2636