### PR TITLE
Add SLURM submission sweep and expose PPO hyperparameters

### DIFF
--- a/business_strategy_gym_env.py
+++ b/business_strategy_gym_env.py
@@ -213,6 +213,61 @@ if __name__ == "__main__":
         action="store_false",
         help="Normalize rewards using VecNormalize (recommended).",
     )
+    parser.add_argument(
+        "--learning-rate",
+        dest="learning_rate",
+        type=float,
+        default=3e-4,
+        help="Learning rate passed to PPO.",
+    )
+    parser.add_argument(
+        "--gamma",
+        type=float,
+        default=0.999,
+        help="Discount factor for future rewards.",
+    )
+    parser.add_argument(
+        "--gae-lambda",
+        dest="gae_lambda",
+        type=float,
+        default=0.95,
+        help="Generalized Advantage Estimation lambda parameter.",
+    )
+    parser.add_argument(
+        "--clip-range",
+        dest="clip_range",
+        type=float,
+        default=0.2,
+        help="Clipping range for the policy objective.",
+    )
+    parser.add_argument(
+        "--ent-coef",
+        dest="ent_coef",
+        type=float,
+        default=0.0,
+        help="Entropy bonus coefficient.",
+    )
+    parser.add_argument(
+        "--vf-coef",
+        dest="vf_coef",
+        type=float,
+        default=0.5,
+        help="Value function loss coefficient.",
+    )
+    parser.add_argument(
+        "--n-steps",
+        dest="n_steps",
+        type=int,
+        default=2048,
+        help="Number of environment steps to run per update.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        dest="batch_size",
+        type=int,
+        default=64,
+        help="Mini-batch size used during PPO updates.",
+    )
 
     args = parser.parse_args()
 
@@ -222,8 +277,7 @@ if __name__ == "__main__":
         else "cpu"
     )
 
-    n_steps = 2048  # StableBaselines3 default value
-    total_steps = n_steps * args.num_envs * args.num_updates
+    total_steps = args.n_steps * args.num_envs * args.num_updates
 
     # Build vectorized envs
     env_fns = [make_env(args.config, i, normalize_observations=args.normalize_obs) for i in range(args.num_envs)]
@@ -237,8 +291,14 @@ if __name__ == "__main__":
     model = stable_baselines3.PPO(
         "MlpPolicy",
         env,
-        gamma=0.999,
-        learning_rate=0.0003, # Default is 0.0003
+        gamma=args.gamma,
+        learning_rate=args.learning_rate, # Default is 0.0003
+        gae_lambda=args.gae_lambda,
+        clip_range=args.clip_range,
+        ent_coef=args.ent_coef,
+        vf_coef=args.vf_coef,
+        n_steps=args.n_steps,
+        batch_size=args.batch_size,
         device=device,
         verbose=1,
     )

--- a/scripts/submit_slurm_ppo_sweep.py
+++ b/scripts/submit_slurm_ppo_sweep.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Submit a PPO hyperparameter sweep where each configuration runs as a SLURM job."""
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+
+def cartesian_product(space: Dict[str, Sequence[object]]) -> Iterable[Dict[str, object]]:
+    """Yield dictionaries representing every point in a hyperparameter grid."""
+
+    keys = list(space.keys())
+    for values in itertools.product(*(space[key] for key in keys)):
+        yield dict(zip(keys, values))
+
+
+def build_submit_command(
+    submit_script: Path,
+    args: argparse.Namespace,
+    job_name: str,
+    output_path: Path,
+    combo: Dict[str, object],
+) -> List[str]:
+    """Create the command used to submit a SLURM job for a single configuration."""
+
+    cmd: List[str] = [
+        str(submit_script),
+        "--config",
+        str(args.config),
+        "--output",
+        str(output_path),
+        "--num-updates",
+        str(args.num_updates),
+        "--num-envs",
+        str(args.num_envs),
+        "--job-name",
+        job_name,
+    ]
+
+    if args.time is not None:
+        cmd.extend(["--time", args.time])
+    if args.partition is not None:
+        cmd.extend(["--partition", args.partition])
+    if args.account is not None:
+        cmd.extend(["--account", args.account])
+    if args.qos is not None:
+        cmd.extend(["--qos", args.qos])
+    if args.nodes is not None:
+        cmd.extend(["--nodes", str(args.nodes)])
+    if args.cpus_per_task is not None:
+        cmd.extend(["--cpus-per-task", str(args.cpus_per_task)])
+    if args.memory is not None:
+        cmd.extend(["--mem", args.memory])
+    if args.gres is not None:
+        cmd.extend(["--gres", args.gres])
+    if args.dependency is not None:
+        cmd.extend(["--dependency", args.dependency])
+    if args.venv is not None:
+        cmd.extend(["--venv", str(args.venv)])
+    if args.build_dir is not None:
+        cmd.extend(["--build-dir", str(args.build_dir)])
+    if args.job_script_dir is not None:
+        job_script = args.job_script_dir / f"{job_name}.sbatch"
+        cmd.extend(["--job-script", str(job_script)])
+    if args.use_gpu:
+        cmd.append("--use-gpu")
+    for extra in args.extra_sbatch:
+        cmd.extend(["--extra-sbatch", extra])
+    if args.dry_run:
+        cmd.append("--dry-run")
+
+    cmd.append("--")
+    for key, value in combo.items():
+        option = f"--{key.replace('_', '-')}"
+        cmd.extend([option, str(value)])
+
+    if args.disable_obs_normalization:
+        cmd.append("--normalize_obs")
+    if args.disable_reward_normalization:
+        cmd.append("--normalize_reward")
+
+    return cmd
+
+
+def main() -> None:
+    base_dir = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(
+        description="Submit a SLURM job per PPO hyperparameter configuration."
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=base_dir / "WorkingFiles" / "Config" / "default.json",
+        help="Simulator configuration to use for every run.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=base_dir / "WorkingFiles" / "Sweeps" / "ppo_slurm",
+        help="Directory where run outputs and metadata will be stored.",
+    )
+    parser.add_argument(
+        "--num-envs",
+        type=int,
+        default=8,
+        help="Number of parallel environments to request per run.",
+    )
+    parser.add_argument(
+        "--num-updates",
+        type=int,
+        default=400,
+        help="Number of PPO updates performed by each job.",
+    )
+    parser.add_argument(
+        "--job-name-prefix",
+        default="ppo-sweep",
+        help="Prefix used when naming SLURM jobs.",
+    )
+    parser.add_argument(
+        "--max-runs",
+        type=int,
+        default=None,
+        help="Optional limit on how many hyperparameter combinations to submit.",
+    )
+    parser.add_argument(
+        "--submit-script",
+        type=Path,
+        default=base_dir / "scripts" / "submit_slurm_training_job.sh",
+        help="Path to the helper that generates the sbatch file.",
+    )
+    parser.add_argument(
+        "--time",
+        help="Requested walltime for each job (e.g., 04:00:00).",
+    )
+    parser.add_argument("--partition", help="SLURM partition/queue name.")
+    parser.add_argument("--account", help="SLURM account to charge.")
+    parser.add_argument("--qos", help="QoS name to request.")
+    parser.add_argument("--nodes", type=int, help="Nodes per job.")
+    parser.add_argument(
+        "--cpus-per-task",
+        type=int,
+        dest="cpus_per_task",
+        help="CPUs per task.",
+    )
+    parser.add_argument("--mem", dest="memory", help="Memory request (e.g., 16G).")
+    parser.add_argument("--gres", help="Generic resource request (e.g., gpu:1).")
+    parser.add_argument("--dependency", help="SLURM dependency specification.")
+    parser.add_argument(
+        "--extra-sbatch",
+        action="append",
+        default=[],
+        help="Additional raw #SBATCH lines to include.",
+    )
+    parser.add_argument(
+        "--venv",
+        type=Path,
+        help="Virtual environment activated inside each job.",
+    )
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        help="Build directory appended to PYTHONPATH inside the job.",
+    )
+    parser.add_argument(
+        "--job-script-dir",
+        type=Path,
+        help="Directory where generated sbatch scripts should be stored.",
+    )
+    parser.add_argument(
+        "--use-gpu",
+        action="store_true",
+        help="Request GPU resources and enable GPU training.",
+    )
+    parser.add_argument(
+        "--disable-obs-normalization",
+        action="store_true",
+        help="Disable observation normalization in the environment.",
+    )
+    parser.add_argument(
+        "--disable-reward-normalization",
+        action="store_true",
+        help="Disable reward normalization during training.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Generate job scripts without submitting to SLURM.",
+    )
+
+    args = parser.parse_args()
+
+    output_dir: Path = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not args.submit_script.exists():
+        raise FileNotFoundError(f"Submission helper not found: {args.submit_script}")
+
+    paired_rollout_settings: Sequence[Tuple[int, int]] = [(1024, 256), (2048, 512)]
+    hyperparameter_space: Dict[str, Sequence[object]] = {
+        "learning_rate": [1e-4, 3e-4, 1e-3],
+        "gamma": [0.99, 0.995, 0.999],
+        "gae_lambda": [0.9, 0.95],
+        "clip_range": [0.15, 0.25],
+        "ent_coef": [0.0, 0.01],
+        "vf_coef": [0.5, 1.0],
+    }
+
+    run_counter = 0
+
+    for n_steps, batch_size in paired_rollout_settings:
+        grid = dict(hyperparameter_space)
+        grid.update({"n_steps": [n_steps], "batch_size": [batch_size]})
+
+        for combo in cartesian_product(grid):
+            if args.max_runs is not None and run_counter >= args.max_runs:
+                break
+
+            run_id = run_counter
+            run_counter += 1
+
+            combo_dir = output_dir / f"run_{run_id:03d}"
+            combo_dir.mkdir(parents=True, exist_ok=True)
+            metadata_path = combo_dir / "hyperparameters.json"
+            metadata_path.write_text(json.dumps(combo, indent=2))
+
+            output_path = combo_dir / "Agent.zip"
+            job_name = f"{args.job_name_prefix}-{run_id:03d}"
+
+            cmd = build_submit_command(
+                args.submit_script,
+                args,
+                job_name,
+                output_path,
+                combo,
+            )
+
+            quoted = " ".join(shlex.quote(part) for part in cmd)
+            print(f"[run {run_id:03d}] {quoted}")
+
+            subprocess.run(cmd, check=True)
+
+        if args.max_runs is not None and run_counter >= args.max_runs:
+            break
+
+    if args.dry_run:
+        print("Dry run complete; inspect the generated sbatch scripts before submitting.")
+    else:
+        print(f"Submitted {run_counter} jobs via {args.submit_script}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expose the PPO hyperparameters and rollout sizing as command-line options in `business_strategy_gym_env.py`
- add a new `submit_slurm_ppo_sweep.py` helper that iterates over a PPO grid and calls the SLURM submission script for each configuration

## Testing
- python scripts/submit_slurm_ppo_sweep.py --max-runs 1 --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68dc15ced63c8326afb78c971e7e430b