### PR TITLE
Create temporary PPO sanity sweep configuration

### DIFF
--- a/TEMP_SWEEP_CHECKLIST.txt
+++ b/TEMP_SWEEP_CHECKLIST.txt
@@ -1,0 +1,51 @@
+Temporary PPO Sweep Sanity Check
+================================
+
+1. Activate the desired Python environment (if applicable).
+
+   ```bash
+   source ~/.venvs/bss/bin/activate  # adjust to your environment
+   ```
+
+2. Navigate to the repository root.
+
+   ```bash
+   cd /workspace/BusinessStrategySimulator3
+   ```
+
+3. (Optional) Clear out any previous temporary sweep artifacts so the run produces
+   fresh output directories.
+
+   ```bash
+   rm -rf WorkingFiles/Sweeps/ppo_slurm/*
+   ```
+
+4. Perform a dry run to confirm the SBATCH commands are generated correctly without
+   submitting any jobs. Limit the run count to keep the check quick.
+
+   ```bash
+   python scripts/submit_slurm_ppo_sweep.py --dry-run --max-runs 2
+   ```
+
+5. Inspect the generated job scripts (if any) and the printed commands to verify the
+   hyperparameters and rollout settings match the temporary mini grid.
+
+6. When ready to exercise the full workflow once, submit the truncated sweep for
+   real (still limited to two runs).
+
+   ```bash
+   python scripts/submit_slurm_ppo_sweep.py --max-runs 2
+   ```
+
+7. Confirm that the run directories and metadata were created as expected.
+
+   ```bash
+   ls WorkingFiles/Sweeps/ppo_slurm
+   cat WorkingFiles/Sweeps/ppo_slurm/run_000/hyperparameters.json
+   ```
+
+8. After verifying the setup, delete this checklist.
+
+   ```bash
+   rm TEMP_SWEEP_CHECKLIST.txt
+   ```

--- a/scripts/submit_slurm_ppo_sweep.py
+++ b/scripts/submit_slurm_ppo_sweep.py
@@ -202,15 +202,24 @@ def main() -> None:
     if not args.submit_script.exists():
         raise FileNotFoundError(f"Submission helper not found: {args.submit_script}")
 
-    paired_rollout_settings: Sequence[Tuple[int, int]] = [(1024, 256), (2048, 512)]
+    # paired_rollout_settings: Sequence[Tuple[int, int]] = [(1024, 256), (2048, 512)]
+    paired_rollout_settings: Sequence[Tuple[int, int]] = [(1024, 256)]
     base_config = json.loads(args.config.read_text())
+    # hyperparameter_space: Dict[str, Sequence[object]] = {
+    #     "learning_rate": [1e-4, 3e-4, 1e-3],
+    #     "gamma": [0.99, 0.995, 0.999],
+    #     "gae_lambda": [0.9, 0.95],
+    #     "clip_range": [0.15, 0.25],
+    #     "ent_coef": [0.0, 0.01],
+    #     "vf_coef": [0.5, 1.0],
+    # }
     hyperparameter_space: Dict[str, Sequence[object]] = {
-        "learning_rate": [1e-4, 3e-4, 1e-3],
-        "gamma": [0.99, 0.995, 0.999],
-        "gae_lambda": [0.9, 0.95],
-        "clip_range": [0.15, 0.25],
-        "ent_coef": [0.0, 0.01],
-        "vf_coef": [0.5, 1.0],
+        "learning_rate": [3e-4, 1e-3],
+        "gamma": [0.99],
+        "gae_lambda": [0.95],
+        "clip_range": [0.2],
+        "ent_coef": [0.0],
+        "vf_coef": [0.5],
     }
 
     run_counter = 0


### PR DESCRIPTION
## Summary
- comment out the full PPO sweep grid and use a minimal configuration for a quick sanity check
- add a temporary checklist with the shell commands needed to verify the truncated sweep

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5484c86908326a6424ac2de3a0d9b