### PR TITLE
Wrap evaluation env with Monitor

### DIFF
--- a/business_strategy_gym_env.py
+++ b/business_strategy_gym_env.py
@@ -5,6 +5,8 @@ import numpy as np
 
 from typing import Callable
 
+from stable_baselines3.common.monitor import Monitor
+
 
 class BusinessStrategyEnv(gym.Env):
     def __init__(self, path_to_config_file, normalize_observations: bool = False):
@@ -163,6 +165,7 @@ class BusinessStrategyEnv(gym.Env):
 def make_env(config_path, seed: int, normalize_observations: bool = False) -> Callable[[], BusinessStrategyEnv]:
     def _init():
         _env = BusinessStrategyEnv(str(config_path), normalize_observations=normalize_observations)
+        _env = Monitor(_env)
         _env.reset(seed=seed)
         return _env
 


### PR DESCRIPTION
## Summary
- wrap each instantiated BusinessStrategyEnv with a Monitor wrapper so evaluation uses monitored envs

## Testing
- python -m compileall business_strategy_gym_env.py

------
https://chatgpt.com/codex/tasks/task_e_68e57c7e231883269edbc11d679eda98