### PR TITLE
Handle missing build directory gracefully in SLURM submission helper

### DIFF
--- a/scripts/submit_slurm_training_job.sh
+++ b/scripts/submit_slurm_training_job.sh
@@ -200,7 +200,13 @@ mkdir -p "$(dirname "$OUTPUT")"
 # environment) so they can adjust the configuration prior to submitting the
 # SLURM job.
 if [[ -n "$BUILD_DIR" && ! -d "$BUILD_DIR" ]]; then
-    echo "Warning: build directory '$BUILD_DIR' does not exist." >&2
+    if [[ "$BUILD_DIR" == "$(make_absolute build)" ]]; then
+        echo "Info: skipping missing default build directory '$BUILD_DIR'." >&2
+        BUILD_DIR=""
+    else
+        echo "Warning: build directory '$BUILD_DIR' does not exist." >&2
+        BUILD_DIR=""
+    fi
 fi
 
 if [[ -n "$VENV_PATH" && ! -f "$VENV_PATH/bin/activate" ]]; then


### PR DESCRIPTION
## Summary
- convert missing build directories into informational warnings and skip appending them to PYTHONPATH
- avoid propagating nonexistent build paths into generated SLURM job scripts

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e57fa369b083269e6437789f74ab1c