### PR TITLE
Stop creating empty simulation_output folders in PPO sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,12 @@ training job before scheduling a sweep.
    directory. Pass a different file with `--config` if your experiment requires
    a custom scenario.
 3. **Decide where results should live.** Each run gets its own folder inside the
-   directory supplied by `--output-dir` (default:
-   `WorkingFiles/Sweeps/ppo_slurm`). That folder will contain:
+  directory supplied by `--output-dir` (default:
+  `WorkingFiles/Sweeps/ppo_slurm`). That folder will contain:
    - `hyperparameters.json`: the exact PPO settings for that job.
    - `config.json`: the generated simulator config handed to the training job.
    - `Agent.zip`: the trained model checkpoint saved by Stable-Baselines3.
-   - `simulation_output/`: simulator-level CSV logs written during evaluation.
+   - Any simulator outputs written during evaluation (if produced).
 4. **Launch the sweep.** Provide whatever SLURM options you normally use when
    calling the single-job helper. The example below requests a GPU partition but
    otherwise relies on defaults:

--- a/scripts/submit_slurm_ppo_sweep.py
+++ b/scripts/submit_slurm_ppo_sweep.py
@@ -241,8 +241,7 @@ def main() -> None:
             metadata_path.write_text(json.dumps(combo, indent=2))
 
             output_path = combo_dir / "Agent.zip"
-            run_results_dir = (combo_dir / "simulation_output").resolve()
-            run_results_dir.mkdir(parents=True, exist_ok=True)
+            run_results_dir = combo_dir.resolve()
 
             combo_config = copy.deepcopy(base_config)
             sim_params = combo_config.setdefault("simulation_parameters", {})


### PR DESCRIPTION
## Summary
- stop creating a `simulation_output` subdirectory for each PPO sweep run
- update the documentation to reflect the streamlined run directory contents

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5852c83588326ab1274a51a07affd