### PR TITLE
Add scripts to extract MasterOutput ends and summarize by folder

### DIFF
--- a/scripts/extract_master_output_ends.py
+++ b/scripts/extract_master_output_ends.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Extract first and final timestep rows from MasterOutput.csv files.
+
+Recursively searches a directory for ``MasterOutput.csv`` files and writes
+``MasterOutputEnds.csv`` next to each source file. For each simulation,
+rows from both the first and final recorded timestep are kept.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+MASTER_OUTPUT_FILENAME = "MasterOutput.csv"
+ENDS_FILENAME = "MasterOutputEnds.csv"
+
+
+def extract_ends(master_output_path: Path) -> Path:
+    """Write a MasterOutputEnds.csv next to a MasterOutput.csv file."""
+    with master_output_path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        fieldnames = reader.fieldnames
+        if fieldnames is None:
+            raise ValueError(f"{master_output_path} has no header row.")
+        if "Sim" not in fieldnames or "Step" not in fieldnames:
+            raise ValueError(
+                f"{master_output_path} must contain 'Sim' and 'Step' columns. "
+                f"Found columns: {fieldnames}"
+            )
+        rows = list(reader)
+
+    min_step_by_sim: dict[str, float] = {}
+    max_step_by_sim: dict[str, float] = {}
+    for row in rows:
+        sim = row["Sim"]
+        step = float(row["Step"])
+        prev_min = min_step_by_sim.get(sim)
+        prev_max = max_step_by_sim.get(sim)
+        if prev_min is None or step < prev_min:
+            min_step_by_sim[sim] = step
+        if prev_max is None or step > prev_max:
+            max_step_by_sim[sim] = step
+
+    end_rows = [
+        row
+        for row in rows
+        if float(row["Step"]) in (min_step_by_sim[row["Sim"]], max_step_by_sim[row["Sim"]])
+    ]
+
+    output_path = master_output_path.with_name(ENDS_FILENAME)
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(end_rows)
+
+    return output_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Recursively find MasterOutput.csv files and write first/final-timestep "
+            "rows to MasterOutputEnds.csv next to each file."
+        )
+    )
+    parser.add_argument(
+        "search_dir",
+        type=Path,
+        help="Directory to search recursively for MasterOutput.csv files.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    search_dir = args.search_dir
+
+    if not search_dir.exists() or not search_dir.is_dir():
+        raise SystemExit(f"Not a directory: {search_dir}")
+
+    master_paths = sorted(search_dir.rglob(MASTER_OUTPUT_FILENAME))
+    if not master_paths:
+        print(f"No {MASTER_OUTPUT_FILENAME} files found under {search_dir}")
+        return
+
+    written = 0
+    for path in master_paths:
+        output_path = extract_ends(path)
+        written += 1
+        print(f"Wrote: {output_path}")
+
+    print(f"Done. Wrote {written} {ENDS_FILENAME} files.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/summarize_ends_by_folder.py
+++ b/scripts/summarize_ends_by_folder.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Summarize bankruptcy and capital growth from MasterOutputEnds.csv files."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+from pathlib import Path
+
+ENDS_FILENAME = "MasterOutputEnds.csv"
+
+
+def mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def stddev_sample(values: list[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    mu = mean(values)
+    variance = sum((v - mu) ** 2 for v in values) / (len(values) - 1)
+    return math.sqrt(variance)
+
+
+def read_csv_rows(path: Path) -> tuple[list[dict[str, str]], list[str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        fieldnames = reader.fieldnames or []
+        return list(reader), fieldnames
+
+
+def summarize_ends_file(
+    path: Path,
+    bankruptcy_value: float,
+    bankruptcy_tol: float,
+) -> list[dict[str, object]]:
+    rows, fieldnames = read_csv_rows(path)
+    required = {"Sim", "Step", "Agent Type", "Capital"}
+    missing = required - set(fieldnames)
+    if missing:
+        raise ValueError(f"{path} is missing required columns: {sorted(missing)}")
+
+    # Identify rows at min/max step for each simulation.
+    min_step_by_sim: dict[str, float] = {}
+    max_step_by_sim: dict[str, float] = {}
+    for row in rows:
+        sim = row["Sim"]
+        step = float(row["Step"])
+        min_step_by_sim[sim] = step if sim not in min_step_by_sim else min(min_step_by_sim[sim], step)
+        max_step_by_sim[sim] = step if sim not in max_step_by_sim else max(max_step_by_sim[sim], step)
+
+    # Group to simulation+agent to derive start/end capital for growth calculations.
+    sim_agent_starts: dict[tuple[str, str], list[float]] = {}
+    sim_agent_ends: dict[tuple[str, str], list[float]] = {}
+
+    # Track final-row bankruptcy flags at row granularity for each agent type.
+    final_bankruptcy_flags_by_agent: dict[str, list[float]] = {}
+
+    for row in rows:
+        sim = row["Sim"]
+        agent_type = row["Agent Type"]
+        step = float(row["Step"])
+        capital = float(row["Capital"])
+
+        if step == min_step_by_sim[sim]:
+            sim_agent_starts.setdefault((sim, agent_type), []).append(capital)
+
+        if step == max_step_by_sim[sim]:
+            sim_agent_ends.setdefault((sim, agent_type), []).append(capital)
+            is_bankrupt = abs(capital - bankruptcy_value) <= bankruptcy_tol
+            final_bankruptcy_flags_by_agent.setdefault(agent_type, []).append(1.0 if is_bankrupt else 0.0)
+
+    growth_rates_by_agent: dict[str, list[float]] = {}
+    for key, end_vals in sim_agent_ends.items():
+        sim, agent_type = key
+        start_vals = sim_agent_starts.get((sim, agent_type), [])
+        if not start_vals:
+            continue
+
+        start_capital = mean(start_vals)
+        end_capital = mean(end_vals)
+        if start_capital == 0.0:
+            continue
+        growth = (end_capital - start_capital) / start_capital
+        growth_rates_by_agent.setdefault(agent_type, []).append(growth)
+
+    all_agent_types = sorted(set(final_bankruptcy_flags_by_agent) | set(growth_rates_by_agent))
+    output_rows: list[dict[str, object]] = []
+    for agent_type in all_agent_types:
+        bankruptcy_flags = final_bankruptcy_flags_by_agent.get(agent_type, [])
+        growth_rates = growth_rates_by_agent.get(agent_type, [])
+        output_rows.append(
+            {
+                "ends_file": str(path),
+                "Agent Type": agent_type,
+                "bankruptcy_rate": mean(bankruptcy_flags),
+                "average_capital_growth_rate": mean(growth_rates),
+                "bankruptcy_sample_count": len(bankruptcy_flags),
+                "growth_sample_count": len(growth_rates),
+            }
+        )
+
+    return output_rows
+
+
+def write_csv(path: Path, rows: list[dict[str, object]], fieldnames: list[str]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "For each immediate child folder of a top-level directory, recursively "
+            "summarize MasterOutputEnds.csv files by agent type and aggregate "
+            "folder-level and top-level statistics."
+        )
+    )
+    parser.add_argument("folder_a", type=Path, help="Top-level folder A.")
+    parser.add_argument(
+        "--bankruptcy-value",
+        type=float,
+        default=-1e-09,
+        help="Capital value used to mark bankruptcy (default: -1e-09).",
+    )
+    parser.add_argument(
+        "--bankruptcy-tol",
+        type=float,
+        default=1e-12,
+        help="Absolute tolerance for bankruptcy-value comparisons.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    folder_a = args.folder_a
+
+    if not folder_a.exists() or not folder_a.is_dir():
+        raise SystemExit(f"Not a directory: {folder_a}")
+
+    child_folders = sorted(p for p in folder_a.iterdir() if p.is_dir())
+    if not child_folders:
+        print(f"No child folders found under {folder_a}")
+        return
+
+    all_folder_means: list[dict[str, object]] = []
+
+    for folder_b in child_folders:
+        ends_paths = sorted(folder_b.rglob(ENDS_FILENAME))
+        if not ends_paths:
+            print(f"No {ENDS_FILENAME} files in {folder_b}; skipping.")
+            continue
+
+        per_file_rows: list[dict[str, object]] = []
+        for ends_path in ends_paths:
+            per_file_rows.extend(
+                summarize_ends_file(
+                    ends_path,
+                    bankruptcy_value=args.bankruptcy_value,
+                    bankruptcy_tol=args.bankruptcy_tol,
+                )
+            )
+
+        per_file_out = folder_b / "ends_per_file_summary.csv"
+        write_csv(
+            per_file_out,
+            per_file_rows,
+            [
+                "ends_file",
+                "Agent Type",
+                "bankruptcy_rate",
+                "average_capital_growth_rate",
+                "bankruptcy_sample_count",
+                "growth_sample_count",
+            ],
+        )
+
+        grouped: dict[str, dict[str, list[float]]] = {}
+        for row in per_file_rows:
+            agent_type = str(row["Agent Type"])
+            grouped.setdefault(agent_type, {"bankruptcy": [], "growth": []})
+            grouped[agent_type]["bankruptcy"].append(float(row["bankruptcy_rate"]))
+            grouped[agent_type]["growth"].append(float(row["average_capital_growth_rate"]))
+
+        folder_mean_rows: list[dict[str, object]] = []
+        for agent_type in sorted(grouped):
+            bankruptcy_values = grouped[agent_type]["bankruptcy"]
+            growth_values = grouped[agent_type]["growth"]
+            row = {
+                "folder_b": str(folder_b),
+                "Agent Type": agent_type,
+                "bankruptcy_rate_mean": mean(bankruptcy_values),
+                "average_capital_growth_rate_mean": mean(growth_values),
+            }
+            folder_mean_rows.append(row)
+            all_folder_means.append(row)
+
+        folder_mean_out = folder_b / "ends_folder_means.csv"
+        write_csv(
+            folder_mean_out,
+            folder_mean_rows,
+            [
+                "folder_b",
+                "Agent Type",
+                "bankruptcy_rate_mean",
+                "average_capital_growth_rate_mean",
+            ],
+        )
+
+        print(f"Wrote: {per_file_out}")
+        print(f"Wrote: {folder_mean_out}")
+
+    if not all_folder_means:
+        print("No folders produced summaries; nothing to aggregate at top level.")
+        return
+
+    grouped_means: dict[str, dict[str, list[float]]] = {}
+    for row in all_folder_means:
+        agent_type = str(row["Agent Type"])
+        grouped_means.setdefault(agent_type, {"bankruptcy": [], "growth": []})
+        grouped_means[agent_type]["bankruptcy"].append(float(row["bankruptcy_rate_mean"]))
+        grouped_means[agent_type]["growth"].append(float(row["average_capital_growth_rate_mean"]))
+
+    top_rows: list[dict[str, object]] = []
+    for agent_type in sorted(grouped_means):
+        bankruptcy_values = grouped_means[agent_type]["bankruptcy"]
+        growth_values = grouped_means[agent_type]["growth"]
+        top_rows.append(
+            {
+                "Agent Type": agent_type,
+                "bankruptcy_rate_mean_of_means": mean(bankruptcy_values),
+                "bankruptcy_rate_std_of_means": stddev_sample(bankruptcy_values),
+                "capital_growth_rate_mean_of_means": mean(growth_values),
+                "capital_growth_rate_std_of_means": stddev_sample(growth_values),
+            }
+        )
+
+    top_out = folder_a / "ends_top_level_mean_std.csv"
+    write_csv(
+        top_out,
+        top_rows,
+        [
+            "Agent Type",
+            "bankruptcy_rate_mean_of_means",
+            "bankruptcy_rate_std_of_means",
+            "capital_growth_rate_mean_of_means",
+            "capital_growth_rate_std_of_means",
+        ],
+    )
+    print(f"Wrote: {top_out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide tooling to reduce large `MasterOutput.csv` files to only first and final timestep rows for downstream analysis. 
- Provide a folder-oriented summarizer to compute bankruptcy rates and capital growth statistics across simulation outputs. 
- Enable aggregation at per-file, per-folder, and top-level scopes for experiment result comparison.

### Description

- Add `scripts/extract_master_output_ends.py` which recursively finds `MasterOutput.csv` files and writes `MasterOutputEnds.csv` containing rows from the first and final recorded timestep for each simulation. 
- Add `scripts/summarize_ends_by_folder.py` which reads `MasterOutputEnds.csv` files, computes per-agent bankruptcy flags (using configurable `--bankruptcy-value` and `--bankruptcy-tol`) and average capital growth rates, and writes `ends_per_file_summary.csv`, `ends_folder_means.csv`, and `ends_top_level_mean_std.csv`. 
- Implement helper utilities for CSV I/O, sample standard deviation (`stddev_sample`), and grouping/aggregation by `Sim` and `Agent Type`. 
- Use explicit error handling for missing columns and invalid directories and provide clear console messages about written output files.

### Testing

- No automated tests were added or run for these scripts in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afaabdb56c8326865ea169a35b3e1e)