### PR TITLE
Optimize MasterOutput end-row extraction for large CSVs

### DIFF
--- a/scripts/extract_master_output_ends.py
+++ b/scripts/extract_master_output_ends.py
@@ -31,41 +31,47 @@ def extract_ends(master_output_path: Path) -> Path:
                 f"{master_output_path} must contain 'Sim' and 'Step' columns. "
                 f"Found columns: {fieldnames}"
             )
-        rows = list(reader)
-
-    print(f"Loaded {len(rows):,} rows from {master_output_path}")
 
     min_step_by_sim: dict[str, float] = {}
     max_step_by_sim: dict[str, float] = {}
-    for index, row in enumerate(rows, start=1):
-        sim = row["Sim"]
-        step = float(row["Step"])
-        prev_min = min_step_by_sim.get(sim)
-        prev_max = max_step_by_sim.get(sim)
-        if prev_min is None or step < prev_min:
-            min_step_by_sim[sim] = step
-        if prev_max is None or step > prev_max:
-            max_step_by_sim[sim] = step
-        if index % ROW_PROGRESS_INTERVAL == 0:
-            print(
-                f"  Progress: evaluated {index:,}/{len(rows):,} rows "
-                f"in {master_output_path.name}"
-            )
+    total_rows = 0
+    with master_output_path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for total_rows, row in enumerate(reader, start=1):
+            sim = row["Sim"]
+            step = float(row["Step"])
+            prev_min = min_step_by_sim.get(sim)
+            prev_max = max_step_by_sim.get(sim)
+            if prev_min is None or step < prev_min:
+                min_step_by_sim[sim] = step
+            if prev_max is None or step > prev_max:
+                max_step_by_sim[sim] = step
+            if total_rows % ROW_PROGRESS_INTERVAL == 0:
+                print(f"  Progress: evaluated {total_rows:,} rows in {master_output_path.name}")
 
-    end_rows = [
-        row
-        for row in rows
-        if float(row["Step"]) in (min_step_by_sim[row["Sim"]], max_step_by_sim[row["Sim"]])
-    ]
+    print(
+        f"First pass complete: scanned {total_rows:,} rows across "
+        f"{len(min_step_by_sim):,} simulations"
+    )
 
     output_path = master_output_path.with_name(ENDS_FILENAME)
+    kept_rows = 0
     with output_path.open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(handle, fieldnames=fieldnames)
         writer.writeheader()
-        writer.writerows(end_rows)
+        with master_output_path.open(newline="", encoding="utf-8") as source_handle:
+            source_reader = csv.DictReader(source_handle)
+            for source_rows, row in enumerate(source_reader, start=1):
+                sim = row["Sim"]
+                step = float(row["Step"])
+                if step in (min_step_by_sim[sim], max_step_by_sim[sim]):
+                    writer.writerow(row)
+                    kept_rows += 1
+                if source_rows % ROW_PROGRESS_INTERVAL == 0:
+                    print(f"  Progress: wrote scan {source_rows:,} rows in {master_output_path.name}")
 
     print(
-        f"Finished {master_output_path.name}: kept {len(end_rows):,} end rows "
+        f"Finished {master_output_path.name}: kept {kept_rows:,} end rows "
         f"across {len(min_step_by_sim):,} simulations"
     )
 


### PR DESCRIPTION
### Motivation
- The script previously materialized entire `MasterOutput.csv` files with `list(reader)`, causing high memory usage and slow execution on large CSVs.
- The slowdown was due to in-memory list allocation rather than whether files were passed as CSVs or ZIPs.
- The goal is to process very large simulation CSVs with low memory use and provide progress feedback during long runs.

### Description
- Replace the single full-read flow with a two-pass streaming approach that first computes per-`Sim` min/max `Step` and then streams the source CSV again to write only matching start/end rows into `MasterOutputEnds.csv`.
- Keep header validation logic and reuse `fieldnames` when writing the output to preserve column order.
- Add streaming-aware progress logging and a `kept_rows` counter for final reporting to avoid relying on a preloaded row count.
- Remove the large intermediate `rows` list to reduce peak memory and improve performance on large files.

### Testing
- Compiled the script with `python -m py_compile scripts/extract_master_output_ends.py` and the compilation succeeded.
- Verified CLI help with `python scripts/extract_master_output_ends.py --help` and the usage text printed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afb39294688326b185e0ae7244a126)