### PR TITLE
Rewrite summarize_ends_by_folder for per-folder mean/std aggregation

### DIFF
--- a/scripts/summarize_ends_by_folder.py
+++ b/scripts/summarize_ends_by_folder.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Summarize bankruptcy and capital growth from MasterOutputEnds.csv files."""
+"""Summarize ending outcomes from MasterOutputEndings.csv files by folder."""
 
 from __future__ import annotations
 
@@ -8,7 +8,9 @@ import csv
 import math
 from pathlib import Path
 
-ENDS_FILENAME = "MasterOutputEnds.csv"
+ENDS_FILENAME = "MasterOutputEndings.csv"
+PER_FILE_SUMMARY_NAME = "endings_per_file_summary.csv"
+FOLDER_SUMMARY_NAME = "endings_folder_summary_mean_std.csv"
 
 
 def mean(values: list[float]) -> float:
@@ -19,7 +21,7 @@ def stddev_sample(values: list[float]) -> float:
     if len(values) < 2:
         return 0.0
     mu = mean(values)
-    variance = sum((v - mu) ** 2 for v in values) / (len(values) - 1)
+    variance = sum((value - mu) ** 2 for value in values) / (len(values) - 1)
     return math.sqrt(variance)
 
 
@@ -30,7 +32,7 @@ def read_csv_rows(path: Path) -> tuple[list[dict[str, str]], list[str]]:
         return list(reader), fieldnames
 
 
-def summarize_ends_file(
+def summarize_endings_file(
     path: Path,
     bankruptcy_value: float,
     bankruptcy_tol: float,
@@ -41,7 +43,7 @@ def summarize_ends_file(
     if missing:
         raise ValueError(f"{path} is missing required columns: {sorted(missing)}")
 
-    # Collapse duplicate market rows first so each sim/step/firm/agent contributes once.
+    # Collapse duplicate rows so each sim/step/firm/agent contributes once.
     dedup_buckets: dict[tuple[str, float, str, str], list[float]] = {}
     for row in rows:
         key = (row["Sim"], float(row["Step"]), row["Firm"], row["Agent Type"])
@@ -52,7 +54,6 @@ def summarize_ends_file(
         for (sim, step, firm, agent_type), capitals in dedup_buckets.items()
     ]
 
-    # Identify start/end step for each firm trajectory.
     min_step_by_firm: dict[tuple[str, str, str], float] = {}
     max_step_by_firm: dict[tuple[str, str, str], float] = {}
     for sim, step, firm, agent_type, _ in dedup_rows:
@@ -60,12 +61,9 @@ def summarize_ends_file(
         min_step_by_firm[key] = step if key not in min_step_by_firm else min(min_step_by_firm[key], step)
         max_step_by_firm[key] = step if key not in max_step_by_firm else max(max_step_by_firm[key], step)
 
-    # Track per-firm start/end capitals for growth calculations.
     start_capital_by_firm: dict[tuple[str, str, str], float] = {}
     end_capital_by_firm: dict[tuple[str, str, str], float] = {}
-
-    # Track bankruptcy flags at per-firm final-step granularity.
-    final_bankruptcy_flags_by_agent: dict[str, list[float]] = {}
+    bankruptcy_flags_by_agent: dict[str, list[float]] = {}
 
     for sim, step, firm, agent_type, capital in dedup_rows:
         firm_key = (sim, firm, agent_type)
@@ -76,37 +74,34 @@ def summarize_ends_file(
         if step == max_step_by_firm[firm_key]:
             end_capital_by_firm[firm_key] = capital
             is_bankrupt = abs(capital - bankruptcy_value) <= bankruptcy_tol
-            final_bankruptcy_flags_by_agent.setdefault(agent_type, []).append(1.0 if is_bankrupt else 0.0)
+            bankruptcy_flags_by_agent.setdefault(agent_type, []).append(1.0 if is_bankrupt else 0.0)
 
     growth_rates_by_agent: dict[str, list[float]] = {}
     for firm_key, end_capital in end_capital_by_firm.items():
         _, _, agent_type = firm_key
         start_capital = start_capital_by_firm.get(firm_key)
-        if start_capital is None:
-            continue
-
-        if start_capital == 0.0:
+        if start_capital in (None, 0.0):
             continue
         growth = (end_capital - start_capital) / start_capital
         growth_rates_by_agent.setdefault(agent_type, []).append(growth)
 
-    all_agent_types = sorted(set(final_bankruptcy_flags_by_agent) | set(growth_rates_by_agent))
-    output_rows: list[dict[str, object]] = []
+    all_agent_types = sorted(set(bankruptcy_flags_by_agent) | set(growth_rates_by_agent))
+    summary_rows: list[dict[str, object]] = []
     for agent_type in all_agent_types:
-        bankruptcy_flags = final_bankruptcy_flags_by_agent.get(agent_type, [])
-        growth_rates = growth_rates_by_agent.get(agent_type, [])
-        output_rows.append(
+        bankruptcy_values = bankruptcy_flags_by_agent.get(agent_type, [])
+        growth_values = growth_rates_by_agent.get(agent_type, [])
+        summary_rows.append(
             {
-                "ends_file": str(path),
+                "endings_file": str(path),
                 "Agent Type": agent_type,
-                "bankruptcy_rate": mean(bankruptcy_flags),
-                "average_capital_growth_rate": mean(growth_rates),
-                "bankruptcy_sample_count": len(bankruptcy_flags),
-                "growth_sample_count": len(growth_rates),
+                "bankruptcy_rate": mean(bankruptcy_values),
+                "average_capital_growth_rate": mean(growth_values),
+                "bankruptcy_sample_count": len(bankruptcy_values),
+                "growth_sample_count": len(growth_values),
             }
         )
 
-    return output_rows
+    return summary_rows
 
 
 def write_csv(path: Path, rows: list[dict[str, object]], fieldnames: list[str]) -> None:
@@ -119,9 +114,9 @@ def write_csv(path: Path, rows: list[dict[str, object]], fieldnames: list[str]) 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "For each immediate child folder of a top-level directory, recursively "
-            "summarize MasterOutputEnds.csv files by agent type and aggregate "
-            "folder-level and top-level statistics."
+            "Given top-level folder A, process each immediate child folder B by "
+            "finding MasterOutputEndings.csv files recursively, writing per-file "
+            "agent summaries, and writing folder-level mean/std summaries across files."
         )
     )
     parser.add_argument("folder_a", type=Path, help="Top-level folder A.")
@@ -142,40 +137,38 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    folder_a = args.folder_a
+    folder_a: Path = args.folder_a
 
     if not folder_a.exists() or not folder_a.is_dir():
         raise SystemExit(f"Not a directory: {folder_a}")
 
-    child_folders = sorted(p for p in folder_a.iterdir() if p.is_dir())
+    child_folders = sorted(path for path in folder_a.iterdir() if path.is_dir())
     if not child_folders:
         print(f"No child folders found under {folder_a}")
         return
 
-    all_folder_means: list[dict[str, object]] = []
-
     for folder_b in child_folders:
-        ends_paths = sorted(folder_b.rglob(ENDS_FILENAME))
-        if not ends_paths:
+        endings_paths = sorted(folder_b.rglob(ENDS_FILENAME))
+        if not endings_paths:
             print(f"No {ENDS_FILENAME} files in {folder_b}; skipping.")
             continue
 
         per_file_rows: list[dict[str, object]] = []
-        for ends_path in ends_paths:
+        for endings_path in endings_paths:
             per_file_rows.extend(
-                summarize_ends_file(
-                    ends_path,
+                summarize_endings_file(
+                    endings_path,
                     bankruptcy_value=args.bankruptcy_value,
                     bankruptcy_tol=args.bankruptcy_tol,
                 )
             )
 
-        per_file_out = folder_b / "ends_per_file_summary.csv"
+        per_file_path = folder_b / PER_FILE_SUMMARY_NAME
         write_csv(
-            per_file_out,
+            per_file_path,
             per_file_rows,
             [
-                "ends_file",
+                "endings_file",
                 "Agent Type",
                 "bankruptcy_rate",
                 "average_capital_growth_rate",
@@ -191,72 +184,39 @@ def main() -> None:
             grouped[agent_type]["bankruptcy"].append(float(row["bankruptcy_rate"]))
             grouped[agent_type]["growth"].append(float(row["average_capital_growth_rate"]))
 
-        folder_mean_rows: list[dict[str, object]] = []
+        folder_rows: list[dict[str, object]] = []
         for agent_type in sorted(grouped):
             bankruptcy_values = grouped[agent_type]["bankruptcy"]
             growth_values = grouped[agent_type]["growth"]
-            row = {
-                "folder_b": str(folder_b),
-                "Agent Type": agent_type,
-                "bankruptcy_rate_mean": mean(bankruptcy_values),
-                "average_capital_growth_rate_mean": mean(growth_values),
-            }
-            folder_mean_rows.append(row)
-            all_folder_means.append(row)
+            folder_rows.append(
+                {
+                    "folder_b": str(folder_b),
+                    "Agent Type": agent_type,
+                    "files_count": len(bankruptcy_values),
+                    "bankruptcy_rate_mean": mean(bankruptcy_values),
+                    "bankruptcy_rate_std": stddev_sample(bankruptcy_values),
+                    "average_capital_growth_rate_mean": mean(growth_values),
+                    "average_capital_growth_rate_std": stddev_sample(growth_values),
+                }
+            )
 
-        folder_mean_out = folder_b / "ends_folder_means.csv"
+        folder_summary_path = folder_b / FOLDER_SUMMARY_NAME
         write_csv(
-            folder_mean_out,
-            folder_mean_rows,
+            folder_summary_path,
+            folder_rows,
             [
                 "folder_b",
                 "Agent Type",
+                "files_count",
                 "bankruptcy_rate_mean",
+                "bankruptcy_rate_std",
                 "average_capital_growth_rate_mean",
+                "average_capital_growth_rate_std",
             ],
         )
 
-        print(f"Wrote: {per_file_out}")
-        print(f"Wrote: {folder_mean_out}")
-
-    if not all_folder_means:
-        print("No folders produced summaries; nothing to aggregate at top level.")
-        return
-
-    grouped_means: dict[str, dict[str, list[float]]] = {}
-    for row in all_folder_means:
-        agent_type = str(row["Agent Type"])
-        grouped_means.setdefault(agent_type, {"bankruptcy": [], "growth": []})
-        grouped_means[agent_type]["bankruptcy"].append(float(row["bankruptcy_rate_mean"]))
-        grouped_means[agent_type]["growth"].append(float(row["average_capital_growth_rate_mean"]))
-
-    top_rows: list[dict[str, object]] = []
-    for agent_type in sorted(grouped_means):
-        bankruptcy_values = grouped_means[agent_type]["bankruptcy"]
-        growth_values = grouped_means[agent_type]["growth"]
-        top_rows.append(
-            {
-                "Agent Type": agent_type,
-                "bankruptcy_rate_mean_of_means": mean(bankruptcy_values),
-                "bankruptcy_rate_std_of_means": stddev_sample(bankruptcy_values),
-                "capital_growth_rate_mean_of_means": mean(growth_values),
-                "capital_growth_rate_std_of_means": stddev_sample(growth_values),
-            }
-        )
-
-    top_out = folder_a / "ends_top_level_mean_std.csv"
-    write_csv(
-        top_out,
-        top_rows,
-        [
-            "Agent Type",
-            "bankruptcy_rate_mean_of_means",
-            "bankruptcy_rate_std_of_means",
-            "capital_growth_rate_mean_of_means",
-            "capital_growth_rate_std_of_means",
-        ],
-    )
-    print(f"Wrote: {top_out}")
+        print(f"Wrote: {per_file_path}")
+        print(f"Wrote: {folder_summary_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Replace the previous top-level aggregation and correct the endings filename/flow so each immediate child folder B of a given top-level folder A produces its own high-level summary from discovered endings files.
- Ensure per-file agent summaries are produced and then treated as the dataset for folder-level statistical aggregation (mean and sample standard deviation).

### Description
- Updated `scripts/summarize_ends_by_folder.py` to target `MasterOutputEndings.csv`, recursively discover those files under each immediate child folder B of the provided top-level `folder_a`, and produce per-file agent summaries written to `endings_per_file_summary.csv` in each folder B.
- Replaced the per-file summarizer with `summarize_endings_file` which deduplicates rows, computes per-agent bankruptcy rates and average capital growth rates (with sample counts), and returns per-file summary rows.
- Added folder-level aggregation that groups per-file means by agent type and writes mean and sample standard deviation for bankruptcy and capital growth to `endings_folder_summary_mean_std.csv` (one file per folder B).
- Removed the previous top-level aggregation across all folders so outputs are scoped per immediate child folder and updated helper functions and CSV field names accordingly.

### Testing
- Ran `python -m py_compile scripts/summarize_ends_by_folder.py` which succeeded.
- Ran `python scripts/summarize_ends_by_folder.py --help` which printed the updated usage and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0564fc7f48326a223d6b5ad23d989)