### PR TITLE
Add --collapse-by-agent-type flag to summarize_ends_by_folder

### DIFF
--- a/scripts/summarize_ends_by_folder.py
+++ b/scripts/summarize_ends_by_folder.py
@@ -32,11 +32,18 @@ def read_csv_rows(path: Path) -> tuple[list[dict[str, str]], list[str]]:
         return list(reader), fieldnames
 
 
+def normalize_agent_type(agent_type: str, collapse_by_agent_type: bool) -> str:
+    if not collapse_by_agent_type:
+        return agent_type
+    return "".join(char for char in agent_type if not char.isdigit())
+
+
 def summarize_endings_file(
     path: Path,
     starting_capital: float,
     bankruptcy_value: float,
     bankruptcy_tol: float,
+    collapse_by_agent_type: bool,
 ) -> list[dict[str, object]]:
     rows, fieldnames = read_csv_rows(path)
     required = {"Sim", "Step", "Firm", "Agent Type", "Capital"}
@@ -47,7 +54,12 @@ def summarize_endings_file(
     # Collapse duplicate rows so each sim/step/firm/agent contributes once.
     dedup_buckets: dict[tuple[str, float, str, str], list[float]] = {}
     for row in rows:
-        key = (row["Sim"], float(row["Step"]), row["Firm"], row["Agent Type"])
+        key = (
+            row["Sim"],
+            float(row["Step"]),
+            row["Firm"],
+            normalize_agent_type(row["Agent Type"], collapse_by_agent_type),
+        )
         dedup_buckets.setdefault(key, []).append(float(row["Capital"]))
 
     dedup_rows: list[tuple[str, float, str, str, float]] = [
@@ -131,6 +143,11 @@ def parse_args() -> argparse.Namespace:
         default=1e-12,
         help="Absolute tolerance for bankruptcy-value comparisons.",
     )
+    parser.add_argument(
+        "--collapse-by-agent-type",
+        action="store_true",
+        help="Strip digits from agent types before aggregating (e.g., 0S/1S -> S).",
+    )
     return parser.parse_args()
 
 
@@ -160,6 +177,7 @@ def main() -> None:
                     starting_capital=args.starting_capital,
                     bankruptcy_value=args.bankruptcy_value,
                     bankruptcy_tol=args.bankruptcy_tol,
+                    collapse_by_agent_type=args.collapse_by_agent_type,
                 )
             )
 


### PR DESCRIPTION
### Motivation
- Provide an option to aggregate agent performance by agent type family rather than specific numbered labels so that sophisticated and naive agents can be reported together (e.g., `0S`, `1S` -> `S`; `2N`, `3N` -> `N`; `4AI` -> `AI`).

### Description
- Add `normalize_agent_type(agent_type, collapse_by_agent_type)` which strips digits from agent type labels when `collapse_by_agent_type` is true. 
- Extend `summarize_endings_file()` to accept a `collapse_by_agent_type` parameter and apply normalization when building dedup/aggregation keys. 
- Add a new CLI flag `--collapse-by-agent-type` in `parse_args()` and pass it through from `main()` so both per-file and folder-level summaries use the collapsed grouping when requested. 
- Keep output CSV column names unchanged so downstream consumers continue to work.

### Testing
- Ran `python3 -m py_compile scripts/summarize_ends_by_folder.py` which succeeded. 
- Ran `python3 scripts/summarize_ends_by_folder.py --help` which succeeded and lists the new `--collapse-by-agent-type` flag. 
- Changes were committed with a descriptive message indicating the new behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b05f542dcc8326baca59103126a773)