### PR TITLE
Suppress interactive heatmap display in random single-sim generator

### DIFF
--- a/scripts/generate_random_single_sim_heatmaps.py
+++ b/scripts/generate_random_single_sim_heatmaps.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pandas as pd
+from unittest.mock import patch
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -71,7 +72,8 @@ def validate_inputs(df: pd.DataFrame, num_plots: int) -> list[int]:
 
 def save_heatmap_for_simulation(df: pd.DataFrame, sim_id: int, output_path: Path) -> None:
     sim_df = df[df["Sim"] == sim_id].copy()
-    plots.plot_firm_market_heatmap(sim_df, sim=sim_id)
+    with patch.object(plt, "show", return_value=None):
+        plots.plot_firm_market_heatmap(sim_df, sim=sim_id)
     plt.gcf().savefig(output_path, dpi=300)
     plt.close(plt.gcf())
 


### PR DESCRIPTION
### Motivation
- Batch generation of single-simulation heatmaps was opening interactive Matplotlib windows for every plot, which is disruptive in non-interactive or automated environments.
- The change prevents `plt.show()` calls from popping up while still allowing figures to be saved to disk.

### Description
- Added `from unittest.mock import patch` to `scripts/generate_random_single_sim_heatmaps.py`.
- Wrapped the call to `plots.plot_firm_market_heatmap(...)` in `with patch.object(plt, "show", return_value=None):` so any internal `plt.show()` calls are suppressed during generation.
- Kept the existing behavior of saving each figure with `plt.gcf().savefig(...)` and closing the figure with `plt.close(...)`.

### Testing
- Ran `python -m py_compile scripts/generate_random_single_sim_heatmaps.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27eb1b610832693fa6c2ea2b41668)