### PR TITLE
Add MIT and CC BY 4.0 licensing structure

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Eric H. Thomas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ BusinessStrategySimulator3 is a research playground for studying market entry an
 - [Batch training helpers](#batch-training-helpers)
 - [Project layout](#project-layout)
 - [Further reading](#further-reading)
+- [Licensing](#licensing)
 
 ## Overview
 
@@ -79,3 +80,7 @@ BusinessStrategySimulator3/
 * [Hyperparameter sweep utilities](docs/hyperparameter_sweeps.md)
 
 The repository serves as a foundation for exploring how reinforcement learning can guide firms when entering or exiting markets.
+
+## Licensing
+
+Code in this repository is licensed under the MIT License (see the root `LICENSE` file). Data assets in `data/` are licensed under CC BY 4.0 (see `data/LICENSE`).

--- a/data/LICENSE
+++ b/data/LICENSE
@@ -1,0 +1,11 @@
+Creative Commons Attribution 4.0 International (CC BY 4.0)
+
+The contents of the `data/` directory are licensed under the
+Creative Commons Attribution 4.0 International License.
+
+License deed: https://creativecommons.org/licenses/by/4.0/
+Legal code: https://creativecommons.org/licenses/by/4.0/legalcode
+
+You are free to share and adapt the material for any purpose,
+even commercially, under the terms of attribution described by
+CC BY 4.0.


### PR DESCRIPTION
### Motivation

- Establish a clear licensing boundary for the repository so code is available under a permissive MIT license and dataset assets will be governed by CC BY 4.0, and prepare the repository for an upcoming dataset upload.

### Description

- Add a root `LICENSE` file containing the standard MIT License text with copyright set to `2026 Eric H. Thomas`.
- Create `data/LICENSE` containing a short CC BY 4.0 notice and links to `https://creativecommons.org/licenses/by/4.0/` and the legal code reference.
- Update `README.md` to add `Licensing` to the table of contents and include a `## Licensing` section that points to the root `LICENSE` for code and `data/LICENSE` for data.

### Testing

- Inspected file contents with `nl -ba README.md`, `nl -ba LICENSE`, and `nl -ba data/LICENSE`, which showed the expected license texts and README updates; these inspections succeeded.
- Reviewed the updated README with `sed -n '1,240p' README.md` to confirm the table of contents and `Licensing` section appear as intended and this inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6b53fa5d88326b2017119347ab65f)