### PR TITLE
Improve single-simulation occupancy legend styling

### DIFF
--- a/Analysis/business_strategy_plots.py
+++ b/Analysis/business_strategy_plots.py
@@ -975,7 +975,7 @@ def plot_firm_market_heatmap(data: pd.DataFrame, step_interval: int = 1, sim: st
     if single_simulation:
         occupancy_legend = [
             patches.Patch(facecolor='#0d2466', edgecolor='black', label='All agents of type present'),
-            patches.Patch(facecolor='#4fb0bf', edgecolor='black', label='One of two agents present (N/A for AI)'),
+            patches.Patch(facecolor='#4fb0bf', edgecolor='black', label='One of two agents present (N/A for AI; there is just one AI agent)'),
             patches.Patch(facecolor='#ecebcf', edgecolor='black', label='No agents of type present'),
         ]
         occupancy_legend_box = ax.legend(

--- a/Analysis/business_strategy_plots.py
+++ b/Analysis/business_strategy_plots.py
@@ -978,14 +978,17 @@ def plot_firm_market_heatmap(data: pd.DataFrame, step_interval: int = 1, sim: st
             patches.Patch(facecolor='#4fb0bf', edgecolor='black', label='One of two agents present (N/A for AI)'),
             patches.Patch(facecolor='#ecebcf', edgecolor='black', label='No agents of type present'),
         ]
-        ax.legend(
+        occupancy_legend_box = ax.legend(
             handles=occupancy_legend,
             title='Single-simulation occupancy',
             loc='upper left',
             bbox_to_anchor=(1.02, 1.0),
             borderaxespad=0,
             frameon=True,
+            fontsize='medium',
+            title_fontsize='large',
         )
+        occupancy_legend_box.get_title().set_fontweight('bold')
 
     # Label x-axis ticks every 50 timesteps to reduce clutter.
     step_values = heatmap_data.columns.to_numpy()


### PR DESCRIPTION
### Motivation
- Improve readability of the "Single-simulation occupancy" legend in the firm/market heatmap for single-simulation plots by making the title bolder and the text larger.

### Description
- In `plot_firm_market_heatmap` the occupancy legend creation for `single_simulation` was changed to capture the legend object as `occupancy_legend_box` and apply styling to it.
- The legend call now passes `fontsize='medium'` and `title_fontsize='large'` to increase entry and title sizes respectively while keeping the same `loc` and `bbox_to_anchor` placement.
- The legend title is explicitly bolded via `occupancy_legend_box.get_title().set_fontweight('bold')` to emphasize the header.
- These are visual-only adjustments and do not change plot layout or data processing logic.

### Testing
- Ran `python -m py_compile Analysis/business_strategy_plots.py` successfully to verify the file compiles without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a44e8ce883268809bf30cf7930ca)