### PR TITLE
Tighten single-simulation occupancy legend spacing

### DIFF
--- a/Analysis/business_strategy_plots.py
+++ b/Analysis/business_strategy_plots.py
@@ -987,6 +987,10 @@ def plot_firm_market_heatmap(data: pd.DataFrame, step_interval: int = 1, sim: st
             frameon=True,
             fontsize='medium',
             title_fontsize='large',
+            alignment='left',
+            borderpad=0.4,
+            labelspacing=0.4,
+            handletextpad=0.7,
         )
         occupancy_legend_box.get_title().set_fontweight('bold')
 


### PR DESCRIPTION
### Motivation
- Reduce awkward internal white space in the "Single-simulation occupancy" legend while keeping all legend text and titles unchanged.

### Description
- Tightened the occupancy legend layout in `plot_firm_market_heatmap` by adding `alignment='left'`, `borderpad=0.4`, `labelspacing=0.4`, and `handletextpad=0.7` to the `ax.legend(...)` call.

### Testing
- Successfully ran `python -m py_compile Analysis/business_strategy_plots.py` to verify the module compiles without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a6d99d20832686dacabac2516dda)